### PR TITLE
Tech: 'Construction' increases queue cap by 1

### DIFF
--- a/js/science.js
+++ b/js/science.js
@@ -117,6 +117,9 @@ dojo.declare("classes.managers.ScienceManager", com.nuclearunicorn.core.TabManag
 		description: $I("science.construction.desc"),
 		effectDesc: $I("science.construction.effectDesc"),
 		prices: [{name : "science", val: 1300}],
+		effects: {
+			"queueCap": 1
+		},
 		unlocks: {
 			buildings: ["logHouse", "warehouse", "lumberMill", "ziggurat"],
 			tech: ["engineering"],


### PR DESCRIPTION
It was discussed that the Technology: 'Construction' could increase queue cap by 1 to help early game.

In this PR it is done by adding an effect to 'Construction'. Since none of the technologies have effects yet, I am not sure if this is the right way to add it. It will also be visible to players even though none of the other techs have it.

We could add an `effectVisible` boolean, which would make it possible to hide the effects of technologies in the future.