### PR TITLE
Queue tooltips

### DIFF
--- a/core.js
+++ b/core.js
@@ -1268,8 +1268,9 @@ dojo.declare("com.nuclearunicorn.game.ui.ButtonModernController", com.nuclearuni
 
 ButtonModernHelper = {
 	getTooltipHTML : function(controller, model){
+		//Some aspects of the metadata may have changed, so fetch the latest version of the model:
+		model = controller.fetchModel(model.options);
 		controller.fetchExtendedModel(model);
-		//throw "ButtonModern::getTooltipHTML must be implemented";
 
 		var tooltip = dojo.create("div", { className: "tooltip-inner" }, null);
 
@@ -1283,7 +1284,7 @@ ButtonModernHelper = {
 
 		// description
 		var descDiv = dojo.create("div", {
-			innerHTML: controller.getDescription(model),
+			innerHTML: model.description,
 			className: "desc"
 		}, tooltip);
 

--- a/game.js
+++ b/game.js
@@ -688,6 +688,10 @@ dojo.declare("com.nuclearunicorn.game.EffectsManager", null, {
 				title: $I("effectsMgr.statics.energyConsumptionIncrease.title"),
 				type: "ratio"
             },
+			"hrHarvesterPenalty":{
+				title: $I("effectsMgr.statics.hrHarvesterPenalty.title"),
+				type: "ratio"
+			},
 
 			//production
 

--- a/js/buildings.js
+++ b/js/buildings.js
@@ -2734,6 +2734,7 @@ dojo.declare("classes.managers.BuildingsManager", com.nuclearunicorn.core.TabMan
 			this.game.render();
 		} else if (data.action == "deltagrade"){ //Generic term for upgrading/downgrading
 			bldMetaRaw.stage = Math.max(0, bldMetaRaw.stage - amt);
+			this.game.time.queue.onDeltagrade(bld.name);
 
 			//Update because it changed when we changed stages
 			bld = new classes.BuildingMeta(bldMetaRaw).getMeta();
@@ -3012,14 +3013,15 @@ dojo.declare("classes.ui.btn.StagingBldBtnController", classes.ui.btn.BuildingBt
 			});
 			this.sellInternal(model, 0, false /*requireSellLink*/);
 		}
-		metadataRaw.stage += delta;
-		if (!metadataRaw.stage) {metadataRaw.stage = Math.max(0, delta);}
+		if (metadataRaw.stage) { metadataRaw.stage = Math.max(0, metadataRaw.stage + delta); }
+		else { metadataRaw.stage = Math.max(0, delta); }
 
 		metadataRaw.val = 0;	//TODO: fix by using separate value flags
 		metadataRaw.on = 0;
 		if (metadataRaw.calculateEffects){
 			metadataRaw.calculateEffects(metadataRaw, this.game);
 		}
+		this.game.time.queue.onDeltagrade(model.options.building);
 		this.game.upgrade(metadataRaw.upgrades);
 		this.game.render();
 	},

--- a/js/jsx/queue.jsx.js
+++ b/js/jsx/queue.jsx.js
@@ -10,6 +10,11 @@ WQueueItem = React.createClass({
     componentDidMount: function(){
         this.attachTooltip();
     },
+    componentDidUpdate: function(prevProps, prevState){
+        if (this.props.item !== prevProps.item) {
+            this.attachTooltip();
+        }
+    },
 
     render: function(){
         var item = this.props.item;
@@ -78,19 +83,13 @@ WQueueItem = React.createClass({
         var game = this.props.game;
 
         var node = React.findDOMNode(this.refs.itemLabel);
-        //TODO: extract controller and model
 
-        //TBD
-        if (item.type != "buildings"){
+        //Extract the correct type of controller & its model for this specific item:
+        var controllerAndModel = game.time.queue.getQueueElementControllerAndModel(item);
+        if (!controllerAndModel) {
             return;
         }
-
-        var controller = new classes.ui.btn.BuildingBtnModernController(game);
-        var model = controller.fetchModel({
-            building: item.name,
-            key: item.name,
-        });
-        UIUtils.attachTooltip(game, node, 0, 200, dojo.partial(ButtonModernHelper.getTooltipHTML, controller, model));
+        UIUtils.attachTooltip(game, node, 0, 200, dojo.partial(ButtonModernHelper.getTooltipHTML, controllerAndModel.controller, controllerAndModel.model));
     }
 });
 

--- a/js/space.js
+++ b/js/space.js
@@ -808,17 +808,20 @@ dojo.declare("classes.managers.SpaceManager", com.nuclearunicorn.core.TabManager
 					{name: "relic", val: 25 }
 				],
 				effects: {
-					"energyProduction": 1
+					"energyProduction": 1,
+					"energyConsumption": 0
 				},
-				calculateEffects: function(self, game) {
+				action: function(self, game){
 					var yearBonus = game.calendar.darkFutureYears();
 					if (yearBonus < 0){
 						yearBonus = 0;
 					}
-
-					self.effects["energyProduction"] =
-						(1 + game.getUnlimitedDR(yearBonus, 0.075) * 0.01) *
-						(1 + game.getEffect("umbraBoostRatio"));
+					var energyRatio = (1 + game.getUnlimitedDR(yearBonus, 0.075) * 0.01) *
+					(1 + game.getEffect("umbraBoostRatio")) * 
+					(1 + game.getEffect("hrHarvesterPenalty"));
+					
+					self.effects["energyProduction"] = Math.max(energyRatio,0);
+					self.effects["energyConsumption"] = Math.abs(Math.min(energyRatio,0));
 				}
 			},{
 				name: "navigationRelay",
@@ -844,6 +847,46 @@ dojo.declare("classes.managers.SpaceManager", com.nuclearunicorn.core.TabManager
 					{name: "eludium", val: 500 }
 				],
 				effects: {} // TBD
+			}, {
+				name: "quantumMesh",
+				label: $I("space.planet.umbra.quantumMesh.label"),
+				description: $I("space.planet.umbra.quantumMesh.desc"),
+				unlocked: false,
+				unlockRatio: 0.6,
+				priceRatio: 1.25,
+				isAutomationEnabled: false,
+				togglable: true,
+				prices: [
+					{name: "antimatter", val: 10000 },
+					{name: "relic", val: 100 }
+				],
+				effects: {
+					"antimatterProduction": 0.5,
+					"antimatterMax": 200,
+					"hrHarvesterPenalty": 0,
+				},
+				action: function(self, game) {
+					var quantumMeshBonusRatio = 1;
+					var amProduction = (0.5 + game.religion.getTU("singularity").val * 0.005);
+					if (self.isAutomationEnabled == null){
+						self.isAutomationEnabled = false;
+					}
+					if (self.isAutomationEnabled) {
+						var activeBuildingPenalty = Math.min(self.on, game.space.getBuilding("hrHarvester").on) * 0.05;
+						var yearBonus = game.calendar.darkFutureYears();
+						if (yearBonus < 0){
+							yearBonus = 0;
+						}
+						quantumMeshBonusRatio = 1 + (game.getUnlimitedDR(yearBonus, 0.075) * 0.01) *
+						(1 + game.getEffect("umbraBoostRatio")) * (game.space.getBuilding("hrHarvester").on);
+						
+						self.effects["hrHarvesterPenalty"] = -activeBuildingPenalty;
+						self.effects["antimatterProduction"] = amProduction + amProduction * quantumMeshBonusRatio * 0.0005;
+					} else{
+						self.effects["hrHarvesterPenalty"] = 0;
+						self.effects["antimatterProduction"] = amProduction;
+					}
+				}
 			}
 		]
 	},{
@@ -964,12 +1007,13 @@ dojo.declare("classes.managers.SpaceManager", com.nuclearunicorn.core.TabManager
 				if (!building.effects){
 					return 0;
 				} else {
-					//There are 4 specially calculated effects that aren't supposed to be multiplied by the number of buildings,
+					//There are 5 specially calculated effects that aren't supposed to be multiplied by the number of buildings,
 					//because they're properties of the building category as a whole, not any individual building.
 					if (effectName === "hashrate" || effectName === "hashRateLevel" ||
-					    effectName === "nextHashLevelAt" || effectName === "hrProgress")
+					    effectName === "nextHashLevelAt" || effectName === "hrProgress" || 
+						effectName === "hrHarvesterPenalty")
 					{
-						//For these 4 specially calculated effects, don't multiply by building.on and don't apply spaceRatio.
+						//For these 5 specially calculated effects, don't multiply by building.on and don't apply spaceRatio.
 						return building.effects[effectName];
 					}
 					//Else, this isn't one of the special effects, so compute it normally.
@@ -1031,7 +1075,7 @@ dojo.declare("classes.managers.SpaceManager", com.nuclearunicorn.core.TabManager
 		for (var i = 0; i < planets.length; i++){
 			var planet = planets[i];
 			if (planet.buildings){
-				planet.buildings = this.filterMetadata(planet.buildings, ["name", "val", "on", "unlocked"]);
+				planet.buildings = this.filterMetadata(planet.buildings, ["name", "val", "on", "unlocked","isAutomationEnabled"]);
 			}
 		}
 
@@ -1106,7 +1150,7 @@ dojo.declare("classes.managers.SpaceManager", com.nuclearunicorn.core.TabManager
 					}
 				}
 
-				if (bld.action && bld.val > 0){
+				if (bld.action && (bld.val > 0 || bld.name == "quantumMesh")){
 					var amt = bld.action(bld, this.game);
 					if (typeof(amt) != "undefined") {
 						bld.lackResConvert = amt != 1 && bld.on != 0;
@@ -1361,6 +1405,12 @@ dojo.declare("classes.ui.space.PlanetBuildingBtnController", com.nuclearunicorn.
 		}
 
 		return prices;
+	},
+
+	handleToggleAutomationLinkClick: function(model) { //specify game.upgrade for planet buildings
+		var building = model.metadata;
+		building.isAutomationEnabled = !building.isAutomationEnabled;
+		this.game.upgrade({spaceBuilding: [building.name]});
 	}
 });
 

--- a/js/time.js
+++ b/js/time.js
@@ -1779,7 +1779,7 @@ dojo.declare("classes.queue.manager", null,{
             value: 1    //always store size of the queue group, even if it is a single item
         });
 
-        if (shiftKey && !this.queueNonStabkable.includes(type)){
+        if (shiftKey && !this.queueNonStackable.includes(type)){
             while(this.queueLength() < this.cap){
                 this.addToQueue(name, type, label, false);
             }

--- a/js/time.js
+++ b/js/time.js
@@ -2262,9 +2262,8 @@ dojo.declare("classes.queue.manager", null,{
                 break;
 
             case "spaceMission":
-                compare = "reached";
                 props.controller = new com.nuclearunicorn.game.ui.SpaceProgramBtnController(this.game);
-                var oldVal = itemMetaRaw.researched;
+                var oldVal = itemMetaRaw.val;
                 var model = props.controller.fetchModel(props);
                 break;
 
@@ -2356,14 +2355,15 @@ dojo.declare("classes.queue.manager", null,{
             //console.log( "Successfully built " + el.name + " using the queue." );
         } else {
             //console.log( "Tried to build " + el.name + " using the queue, but failed." );
-        }
-
-        if(compare == "research" || compare == "reached" && model.metadata[compare] == true
-            || (compare.includes("blocked") && model.metadata["blocked"] == true) ||
-            (compare.includes("research") && model.metadata["research"] == true)
-        ){
-            this.dropLastItem();
-            this.game._publish("ui/update", this.game);
+            if( (compare == "researched" && model.metadata[compare] == true ) ||
+                (compare.includes("blocked") && model.metadata["blocked"] == true) ||
+                (compare.includes("researched") && model.metadata["researched"] == true) ||
+                (el.type === "spaceMission" && model.metadata[compare])
+            ){
+                this.dropLastItem();
+                this.game._publish("ui/update", this.game);
+                //console.log( "Dropped " + el.name + " from the queue because it can't be built anymore." );
+            }
         }
     }
 });

--- a/js/time.js
+++ b/js/time.js
@@ -1417,7 +1417,12 @@ dojo.declare("classes.ui.time.FixCryochamberBtnController", com.nuclearunicorn.g
 
 	updateVisible: function(model) {
 		model.visible = this.game.workshop.get("chronoforge").researched && this.game.time.getVSU("usedCryochambers").val != 0;
-	}
+	},
+
+    //This is a bit of a hack to get the correct description to appear in the queue tooltips...
+    getDescription: function(model) {
+        return $I("time.fixCryochambers.desc");
+    }
 });
 
 dojo.declare("classes.ui.VoidSpaceWgt", [mixin.IChildrenAware, mixin.IGameAware], {
@@ -2083,7 +2088,13 @@ dojo.declare("classes.queue.manager", null,{
         this.dropLastItem();
         this.showList();
     },
-    getQueueElementModel: function(el){
+    getQueueElementModel: function(el) {
+        var controllerAndModel = this.getQueueElementControllerAndModel(el);
+        if (controllerAndModel) {
+            return controllerAndModel.model;
+        }
+    },
+    getQueueElementControllerAndModel: function(el){
         var itemMetaRaw = this.game.getUnlockByName(el.name, el.type);
         if (!itemMetaRaw){
             console.error("invalid queue item:", el);
@@ -2142,7 +2153,7 @@ dojo.declare("classes.queue.manager", null,{
                     itemMetaRaw = this.game.getUnlockByName("cryochambers", el.type);
                     model.prices = this.game.time.getVSU("usedCryochambers").fixPrices;
                     model.enabled = this.game.resPool.hasRes(model.prices); //check we actually have enough to do one fix!
-                    console.log(model);
+                    //console.log(model);
                 }
                 break;
 
@@ -2184,8 +2195,7 @@ dojo.declare("classes.queue.manager", null,{
                 var model = props.controller.fetchModel(props);
                 break;
         }
-        //return props, model;
-        return model;
+        return { controller: props.controller, model: model };
     },
     update: function(){
         this.cap = this.calculateCap();
@@ -2279,7 +2289,7 @@ dojo.declare("classes.queue.manager", null,{
                     itemMetaRaw = this.game.getUnlockByName("cryochambers", el.type);
                     model.prices = this.game.time.getVSU("usedCryochambers").fixPrices;
                     model.enabled = this.game.resPool.hasRes(model.prices); //check we actually have enough to do one fix!
-                    console.log(model);
+                    //console.log(model);
                 }
                 break;
 

--- a/js/time.js
+++ b/js/time.js
@@ -2365,5 +2365,27 @@ dojo.declare("classes.queue.manager", null,{
                 //console.log( "Dropped " + el.name + " from the queue because it can't be built anymore." );
             }
         }
+    },
+
+    //This function is to be called whenever a building is deltagraded.
+    //This function iterates through all queue items with the same internal ID as the
+    //deltagraded building & updates their labels to match the new version.
+    //@param itemName   String.  The ID of whichever building was deltagraded.
+    onDeltagrade: function(itemName) {
+        var buildingsManager = this.game.bld;
+        dojo.forEach(this.queueItems, function(item) {
+            if(!item || item.name !== itemName) {
+                return;
+            }
+            //Else, we have here a valid queue item matching the name of what was deltagraded.
+            if(item.type === "buildings") {
+                var building = buildingsManager.getBuildingExt(itemName).meta;
+                var newLabel = building.label;
+                if(building.stages){
+                    newLabel = building.stages[building.stage].label;
+                }
+                item.label = newLabel;
+            }
+        });
     }
 });

--- a/res/i18n/en.json
+++ b/res/i18n/en.json
@@ -410,6 +410,7 @@
     "effectsMgr.statics.energyConsumptionRatio.title": "Energy consumption reduction",
     "effectsMgr.statics.energyProduction.title": "Energy production",
     "effectsMgr.statics.energyProductionRatio.title": "Energy production bonus",
+    "effectsMgr.statics.hrHarvesterPenalty.title": "HR Harvester Penalty",
     "effectsMgr.statics.entangler-gflopsConsumption.title": "Entanglement St. - GFlops conversion",
     "effectsMgr.statics.entangler-hrProgress.title": "Hash collision",
     
@@ -1475,6 +1476,8 @@
     "space.planet.umbra.navigationRelay.desc": "Increase your crew cap by one",
     "space.planet.umbra.spaceShuttle.label": "Space Shuttle",
     "space.planet.umbra.spaceShuttle.desc": "Staffed with science crew",
+    "space.planet.umbra.quantumMesh.label": "Quantum Mesh",
+    "space.planet.umbra.quantumMesh.desc": "Captures antimatter from the matter fields imbalanced by the black hole<br><br>Automation: Increases Quantum Mesh effectiveness by reducing HR Harvester energy production",
     "space.planet.yarn.label": "Yarn",
     "space.planet.yarn.hydroponics.label": "Hydroponics",
     "space.planet.yarn.hydroponics.desc": "State of the art automated hydroponic system. Increase catnip limit by 10%. Increase catnip production by 2.5%",


### PR DESCRIPTION
- Any item that can be queued now has the appropriate tooltip inside the queue itself.
- Tooltips update everything that changes.  So now when you build stuff in the queue, the price listed in the tooltip will go up as expected.
- The queue drops items from the list if they are already purchased (this already existed in the code but had a couple bugs).
- Fixed a bug when using the SHIFT key to queue multiple items at once.
- Whenever a building is deltagraded, the labels of relevant queued items update to match.