### PR TITLE
Queue tooltips (again)

### DIFF
--- a/core.js
+++ b/core.js
@@ -1268,8 +1268,9 @@ dojo.declare("com.nuclearunicorn.game.ui.ButtonModernController", com.nuclearuni
 
 ButtonModernHelper = {
 	getTooltipHTML : function(controller, model){
+		//Some aspects of the metadata may have changed, so fetch the latest version of the model:
+		model = controller.fetchModel(model.options);
 		controller.fetchExtendedModel(model);
-		//throw "ButtonModern::getTooltipHTML must be implemented";
 
 		var tooltip = dojo.create("div", { className: "tooltip-inner" }, null);
 
@@ -1283,7 +1284,7 @@ ButtonModernHelper = {
 
 		// description
 		var descDiv = dojo.create("div", {
-			innerHTML: controller.getDescription(model),
+			innerHTML: model.description,
 			className: "desc"
 		}, tooltip);
 

--- a/js/buildings.js
+++ b/js/buildings.js
@@ -2734,6 +2734,7 @@ dojo.declare("classes.managers.BuildingsManager", com.nuclearunicorn.core.TabMan
 			this.game.render();
 		} else if (data.action == "deltagrade"){ //Generic term for upgrading/downgrading
 			bldMetaRaw.stage = Math.max(0, bldMetaRaw.stage - amt);
+			this.game.time.queue.onDeltagrade(bld.name);
 
 			//Update because it changed when we changed stages
 			bld = new classes.BuildingMeta(bldMetaRaw).getMeta();
@@ -3012,14 +3013,15 @@ dojo.declare("classes.ui.btn.StagingBldBtnController", classes.ui.btn.BuildingBt
 			});
 			this.sellInternal(model, 0, false /*requireSellLink*/);
 		}
-		metadataRaw.stage += delta;
-		if (!metadataRaw.stage) {metadataRaw.stage = Math.max(0, delta);}
+		if (metadataRaw.stage) { metadataRaw.stage = Math.max(0, metadataRaw.stage + delta); }
+		else { metadataRaw.stage = Math.max(0, delta); }
 
 		metadataRaw.val = 0;	//TODO: fix by using separate value flags
 		metadataRaw.on = 0;
 		if (metadataRaw.calculateEffects){
 			metadataRaw.calculateEffects(metadataRaw, this.game);
 		}
+		this.game.time.queue.onDeltagrade(model.options.building);
 		this.game.upgrade(metadataRaw.upgrades);
 		this.game.render();
 	},

--- a/js/jsx/queue.jsx.js
+++ b/js/jsx/queue.jsx.js
@@ -10,6 +10,11 @@ WQueueItem = React.createClass({
     componentDidMount: function(){
         this.attachTooltip();
     },
+    componentDidUpdate: function(prevProps, prevState){
+        if (this.props.item !== prevProps.item) {
+            this.attachTooltip();
+        }
+    },
 
     render: function(){
         var item = this.props.item;
@@ -78,19 +83,13 @@ WQueueItem = React.createClass({
         var game = this.props.game;
 
         var node = React.findDOMNode(this.refs.itemLabel);
-        //TODO: extract controller and model
 
-        //TBD
-        if (item.type != "buildings"){
+        //Extract the correct type of controller & its model for this specific item:
+        var controllerAndModel = game.time.queue.getQueueElementControllerAndModel(item);
+        if (!controllerAndModel) {
             return;
         }
-
-        var controller = new classes.ui.btn.BuildingBtnModernController(game);
-        var model = controller.fetchModel({
-            building: item.name,
-            key: item.name,
-        });
-        UIUtils.attachTooltip(game, node, 0, 200, dojo.partial(ButtonModernHelper.getTooltipHTML, controller, model));
+        UIUtils.attachTooltip(game, node, 0, 200, dojo.partial(ButtonModernHelper.getTooltipHTML, controllerAndModel.controller, controllerAndModel.model));
     }
 });
 

--- a/js/time.js
+++ b/js/time.js
@@ -1779,7 +1779,7 @@ dojo.declare("classes.queue.manager", null,{
             value: 1    //always store size of the queue group, even if it is a single item
         });
 
-        if (shiftKey && !this.queueNonStabkable.includes(type)){
+        if (shiftKey && !this.queueNonStackable.includes(type)){
             while(this.queueLength() < this.cap){
                 this.addToQueue(name, type, label, false);
             }

--- a/js/time.js
+++ b/js/time.js
@@ -2262,9 +2262,8 @@ dojo.declare("classes.queue.manager", null,{
                 break;
 
             case "spaceMission":
-                compare = "reached";
                 props.controller = new com.nuclearunicorn.game.ui.SpaceProgramBtnController(this.game);
-                var oldVal = itemMetaRaw.researched;
+                var oldVal = itemMetaRaw.val;
                 var model = props.controller.fetchModel(props);
                 break;
 
@@ -2356,14 +2355,15 @@ dojo.declare("classes.queue.manager", null,{
             //console.log( "Successfully built " + el.name + " using the queue." );
         } else {
             //console.log( "Tried to build " + el.name + " using the queue, but failed." );
-        }
-
-        if(compare == "research" || compare == "reached" && model.metadata[compare] == true
-            || (compare.includes("blocked") && model.metadata["blocked"] == true) ||
-            (compare.includes("research") && model.metadata["research"] == true)
-        ){
-            this.dropLastItem();
-            this.game._publish("ui/update", this.game);
+            if( (compare == "researched" && model.metadata[compare] == true ) ||
+                (compare.includes("blocked") && model.metadata["blocked"] == true) ||
+                (compare.includes("researched") && model.metadata["researched"] == true) ||
+                (el.type === "spaceMission" && model.metadata[compare])
+            ){
+                this.dropLastItem();
+                this.game._publish("ui/update", this.game);
+                //console.log( "Dropped " + el.name + " from the queue because it can't be built anymore." );
+            }
         }
     }
 });

--- a/js/time.js
+++ b/js/time.js
@@ -1417,7 +1417,12 @@ dojo.declare("classes.ui.time.FixCryochamberBtnController", com.nuclearunicorn.g
 
 	updateVisible: function(model) {
 		model.visible = this.game.workshop.get("chronoforge").researched && this.game.time.getVSU("usedCryochambers").val != 0;
-	}
+	},
+
+    //This is a bit of a hack to get the correct description to appear in the queue tooltips...
+    getDescription: function(model) {
+        return $I("time.fixCryochambers.desc");
+    }
 });
 
 dojo.declare("classes.ui.VoidSpaceWgt", [mixin.IChildrenAware, mixin.IGameAware], {
@@ -2083,7 +2088,13 @@ dojo.declare("classes.queue.manager", null,{
         this.dropLastItem();
         this.showList();
     },
-    getQueueElementModel: function(el){
+    getQueueElementModel: function(el) {
+        var controllerAndModel = this.getQueueElementControllerAndModel(el);
+        if (controllerAndModel) {
+            return controllerAndModel.model;
+        }
+    },
+    getQueueElementControllerAndModel: function(el){
         var itemMetaRaw = this.game.getUnlockByName(el.name, el.type);
         if (!itemMetaRaw){
             console.error("invalid queue item:", el);
@@ -2142,7 +2153,7 @@ dojo.declare("classes.queue.manager", null,{
                     itemMetaRaw = this.game.getUnlockByName("cryochambers", el.type);
                     model.prices = this.game.time.getVSU("usedCryochambers").fixPrices;
                     model.enabled = this.game.resPool.hasRes(model.prices); //check we actually have enough to do one fix!
-                    console.log(model);
+                    //console.log(model);
                 }
                 break;
 
@@ -2184,8 +2195,7 @@ dojo.declare("classes.queue.manager", null,{
                 var model = props.controller.fetchModel(props);
                 break;
         }
-        //return props, model;
-        return model;
+        return { controller: props.controller, model: model };
     },
     update: function(){
         this.cap = this.calculateCap();
@@ -2279,7 +2289,7 @@ dojo.declare("classes.queue.manager", null,{
                     itemMetaRaw = this.game.getUnlockByName("cryochambers", el.type);
                     model.prices = this.game.time.getVSU("usedCryochambers").fixPrices;
                     model.enabled = this.game.resPool.hasRes(model.prices); //check we actually have enough to do one fix!
-                    console.log(model);
+                    //console.log(model);
                 }
                 break;
 

--- a/js/time.js
+++ b/js/time.js
@@ -2365,5 +2365,27 @@ dojo.declare("classes.queue.manager", null,{
                 //console.log( "Dropped " + el.name + " from the queue because it can't be built anymore." );
             }
         }
+    },
+
+    //This function is to be called whenever a building is deltagraded.
+    //This function iterates through all queue items with the same internal ID as the
+    //deltagraded building & updates their labels to match the new version.
+    //@param itemName   String.  The ID of whichever building was deltagraded.
+    onDeltagrade: function(itemName) {
+        var buildingsManager = this.game.bld;
+        dojo.forEach(this.queueItems, function(item) {
+            if(!item || item.name !== itemName) {
+                return;
+            }
+            //Else, we have here a valid queue item matching the name of what was deltagraded.
+            if(item.type === "buildings") {
+                var building = buildingsManager.getBuildingExt(itemName).meta;
+                var newLabel = building.label;
+                if(building.stages){
+                    newLabel = building.stages[building.stage].label;
+                }
+                item.label = newLabel;
+            }
+        });
     }
 });


### PR DESCRIPTION
This is a duplicate of pull request #10, Queue Tooltips
- Any item that can be queued now has the appropriate tooltip inside the queue itself.
- Tooltips update everything that changes. So now when you build stuff in the queue, the price listed in the tooltip will go up as expected.
- The queue drops items from the list if they are already purchased (this already existed in the code but had a couple bugs).
- Fixed a bug when using the SHIFT key to queue multiple items at once.
- Whenever a building is deltagraded, the labels of relevant queued items update to match.