### PR TITLE
Refactor buyItem & Queue Improvements

### DIFF
--- a/core.js
+++ b/core.js
@@ -1268,8 +1268,9 @@ dojo.declare("com.nuclearunicorn.game.ui.ButtonModernController", com.nuclearuni
 
 ButtonModernHelper = {
 	getTooltipHTML : function(controller, model){
+		//Some aspects of the metadata may have changed, so fetch the latest version of the model:
+		model = controller.fetchModel(model.options);
 		controller.fetchExtendedModel(model);
-		//throw "ButtonModern::getTooltipHTML must be implemented";
 
 		var tooltip = dojo.create("div", { className: "tooltip-inner" }, null);
 
@@ -1283,7 +1284,7 @@ ButtonModernHelper = {
 
 		// description
 		var descDiv = dojo.create("div", {
-			innerHTML: controller.getDescription(model),
+			innerHTML: model.description,
 			className: "desc"
 		}, tooltip);
 

--- a/core.js
+++ b/core.js
@@ -749,6 +749,7 @@ dojo.declare("com.nuclearunicorn.game.ui.ButtonController", null, {
 			return;
 		}
 		//Else, we meet all requirements to buy this item:
+		if (!event) { event = {}; /*event is an optional parameter*/ }
 		this.clickHandler(model, event);
 		this.payPrice(model);
 
@@ -2031,6 +2032,7 @@ dojo.declare("com.nuclearunicorn.game.ui.BuildingStackableBtnController", com.nu
 	},
 
 	_buyItem_step2: function(model, event, callback) {
+		if (!event) { event = {}; /*event is an optional parameter*/ }
 		//This is what we pass to the callback function if we succeed:
 		var resultIfBuySuccessful = { itemBought: true, reason: (this.game.devMode ? "dev-mode" : "paid-for") };
 

--- a/core.js
+++ b/core.js
@@ -707,6 +707,38 @@ dojo.declare("com.nuclearunicorn.game.ui.ButtonController", null, {
 		model.handler.apply(this, [model, event]);
 	},
 
+	/* This is probably the most important function in the button's code--when you click the button, it does the thing.
+	 * This function also handles logic such as "what if you click the button but can't afford it right now."
+	 * The name "buy item" is somewhat misleading, as ALL buttons in the UI (at least, all that inherit from this class)
+	 * use this function.  Buttons like the "send hunters" button or the "reset game" button use their clickHandler to do the thing.
+	 * Other buttons such as those for buildings or techs override the buyItem function to put their own custom logic in, but
+	 * all implementations of buyItem follow the same principles.
+	 * @param model	Object.  The model of this item.  For those unfamiliar with the Kittens Game game engine, the model
+	 * 				specifies data such as the name of the item, whether it's visible, whether it's enabled, its prices,
+	 * 				its effects, the metadata associated with this building, etc.
+	 * @param event	(OPTIONAL) Object.  If given, contains information such as whether the shift key was pressed.  This is
+	 * 				used by buildings to determine if we're buying 1, buying 10, buying all, etc.  If null, uses default behavior.
+	 * @param callback	Function.  This is how we communicate the results of trying to buy the item.  The callback function is called
+	 * 				with a single parameter, an object containing two fields:
+	 * 					itemBought	Boolean.  True if one or more items were bought, false if nothing happened.
+	 * 					reason		String.  Used as an enumeration encoding *why* the result happened the way it did.
+	 * 								If itemBought is true, can be one of the following values:
+	 * 									"paid-for"		We met the requirements & bought the item legitimately.
+	 * 									"dev-mode"		We bought this item in dev mode ignoring the cost & requirements.
+	 * 									"item-is-free"		The item has no cost or requirements.
+	 * 								If itemBought is false, can be one of the following values:
+	 * 									"not-unlocked"		The item is not unlocked yet.
+	 * 									"already-bought"	For one-time purchases, the item is already bought.
+	 * 													For purchases with a limit, we are at that limit.
+	 * 									"blocked"			A conflicting item has already been bought.
+	 * 													Also used by some policies to indicate additional unmet requirements.
+	 * 									"player-denied"	This item requires the player to confirm their choice, but
+	 * 													the player decided not to confirm the purchase.
+	 * 									"cannot-afford"	The player can't afford the price of this item right now.
+	 * 									"not-enabled"		For some unspecified reason, this item is not available.
+	 * 				If the callback function returns anything, the return value from that function is ignored.
+	 * @return		No return value.  We communicate with the rest of the program using the callback function.
+	 */
 	buyItem: function(model, event, callback){
 		if (!this.hasResources(model)) {
 			callback({ itemBought: false, reason: "cannot-afford" });

--- a/core.js
+++ b/core.js
@@ -1971,7 +1971,16 @@ dojo.declare("com.nuclearunicorn.game.ui.BuildingStackableBtnController", com.nu
 			return;
 		}
 		if (!model.enabled && !isInDevMode) {
-			callback({ itemBought: false, reason: "not-enabled" });
+			//Give a more detailed reason of why we can't buy it at this time:
+			var whyArentWeEnabled = "not-enabled"; //(default reason--unspecified)
+			var meta = model.metadata;
+			if (typeof(meta.limitBuild) == "number" && meta.limitBuild <= meta.val) {
+				whyArentWeEnabled = "already-bought";
+			} else if (meta.on && meta.noStackable){
+				whyArentWeEnabled = "already-bought";
+			}
+
+			callback({ itemBought: false, reason: whyArentWeEnabled });
 			return;
 		}
 		//Else, we meet all the requirements for being able to buy this item:

--- a/js/buildings.js
+++ b/js/buildings.js
@@ -2734,6 +2734,7 @@ dojo.declare("classes.managers.BuildingsManager", com.nuclearunicorn.core.TabMan
 			this.game.render();
 		} else if (data.action == "deltagrade"){ //Generic term for upgrading/downgrading
 			bldMetaRaw.stage = Math.max(0, bldMetaRaw.stage - amt);
+			this.game.time.queue.onDeltagrade(bld.name);
 
 			//Update because it changed when we changed stages
 			bld = new classes.BuildingMeta(bldMetaRaw).getMeta();
@@ -3012,14 +3013,15 @@ dojo.declare("classes.ui.btn.StagingBldBtnController", classes.ui.btn.BuildingBt
 			});
 			this.sellInternal(model, 0, false /*requireSellLink*/);
 		}
-		metadataRaw.stage += delta;
-		if (!metadataRaw.stage) {metadataRaw.stage = Math.max(0, delta);}
+		if (metadataRaw.stage) { metadataRaw.stage = Math.max(0, metadataRaw.stage + delta); }
+		else { metadataRaw.stage = Math.max(0, delta); }
 
 		metadataRaw.val = 0;	//TODO: fix by using separate value flags
 		metadataRaw.on = 0;
 		if (metadataRaw.calculateEffects){
 			metadataRaw.calculateEffects(metadataRaw, this.game);
 		}
+		this.game.time.queue.onDeltagrade(model.options.building);
 		this.game.upgrade(metadataRaw.upgrades);
 		this.game.render();
 	},

--- a/js/buildings.js
+++ b/js/buildings.js
@@ -2764,7 +2764,7 @@ dojo.declare("classes.game.ui.GatherCatnipButtonController", com.nuclearunicorn.
 		}
 
 		this.game.bld.gatherCatnip();
-		callback(true);
+		callback({ itemBought: true, reason: "item-is-free" /*It costs no resources to gather catnip, so we can't fail to buy it*/});
 	}
 });
 

--- a/js/challenges.js
+++ b/js/challenges.js
@@ -713,30 +713,8 @@ dojo.declare("classes.ui.ChallengeBtnController", com.nuclearunicorn.game.ui.Bui
 	},
 
 	buyItem: function(model, event, callback) {
-		/*if (model.metadata.name == this.game.challenges.currentChallenge
-		 || (!model.enabled && !this.game.devMode)) {
-			callback(false);
-			return;
-		}
-
-		var game = this.game;
-		game.ui.confirm($I("challendge.btn.confirmation.title"), $I("challendge.btn.confirmation.msg"), function() {
-			// Set the challenge for after reset
-			game.challenges.currentChallenge = model.metadata.name == "ironWill"
-				? null
-				: model.metadata.name;
-			// Reset with any benefit of chronosphere (resources, kittens, etc...)
-			game.bld.get("chronosphere").val = 0;
-			game.bld.get("chronosphere").on = 0;
-			game.time.getVSU("cryochambers").val = 0;
-			game.time.getVSU("cryochambers").on = 0;
-			game.resetAutomatic();
-			callback(true);
-		}, function() {
-			callback(false);
-		});*/
-
 		this.togglePending(model);
+		callback({ itemBought: true, reason: "item-is-free" /*We just toggled the pending state; simple, really*/});
 	},
 
 	togglePending: function(model){

--- a/js/jsx/queue.jsx.js
+++ b/js/jsx/queue.jsx.js
@@ -10,6 +10,11 @@ WQueueItem = React.createClass({
     componentDidMount: function(){
         this.attachTooltip();
     },
+    componentDidUpdate: function(prevProps, prevState){
+        if (this.props.item !== prevProps.item) {
+            this.attachTooltip();
+        }
+    },
 
     render: function(){
         var item = this.props.item;
@@ -78,19 +83,13 @@ WQueueItem = React.createClass({
         var game = this.props.game;
 
         var node = React.findDOMNode(this.refs.itemLabel);
-        //TODO: extract controller and model
 
-        //TBD
-        if (item.type != "buildings"){
+        //Extract the correct type of controller & its model for this specific item:
+        var controllerAndModel = game.time.queue.getQueueElementControllerAndModel(item);
+        if (!controllerAndModel) {
             return;
         }
-
-        var controller = new classes.ui.btn.BuildingBtnModernController(game);
-        var model = controller.fetchModel({
-            building: item.name,
-            key: item.name,
-        });
-        UIUtils.attachTooltip(game, node, 0, 200, dojo.partial(ButtonModernHelper.getTooltipHTML, controller, model));
+        UIUtils.attachTooltip(game, node, 0, 200, dojo.partial(ButtonModernHelper.getTooltipHTML, controllerAndModel.controller, controllerAndModel.model));
     }
 });
 

--- a/js/prestige.js
+++ b/js/prestige.js
@@ -543,7 +543,7 @@ dojo.declare("classes.ui.PrestigeBtnController", com.nuclearunicorn.game.ui.Buil
 		if (this.game.science.get("metaphysics").researched) {
 			this.inherited(arguments);
 		} else {
-			callback(false);
+			callback({ itemBought: false, reason: "not-unlocked" });
 		}
 	},
 

--- a/js/religion.js
+++ b/js/religion.js
@@ -1381,6 +1381,7 @@ dojo.declare("classes.ui.religion.TransformBtnController", com.nuclearunicorn.ga
 			callback({ itemBought: false, reason: "not-enabled" });
 			return;
 		}
+		if (!event) { event = {}; /*event is an optional parameter*/ }
 		var batchSize = event.shiftKey ? 10000 :
 			event.ctrlKey || event.metaKey ? this.game.opts.batchSize : 1;
 		var didWeSucceed = this._transform(model, batchSize);
@@ -1486,7 +1487,7 @@ dojo.declare("classes.ui.religion.RefineTearsBtnController", com.nuclearunicorn.
 				&& self._canAfford(model, count) >= count,
 			title: "x" + count,
 			handler: function (event) {
-				self.buyItem(model, {}, this.update.bind(this), count);
+				self.buyItem(model, null, this.update.bind(this), count);
 			}
 		};
 	},
@@ -1512,6 +1513,7 @@ dojo.declare("classes.ui.religion.RefineTearsBtnController", com.nuclearunicorn.
 			callback({ itemBought: false, reason: "already-bought" });
 			return;
 		}
+		if (!event) { event = {}; /*event is an optional parameter*/ }
 		for (var batchSize = count || (event.ctrlKey ? this.game.opts.batchSize : 1);
 			 batchSize > 0
 			 && this.hasResources(model)

--- a/js/religion.js
+++ b/js/religion.js
@@ -1371,12 +1371,23 @@ dojo.declare("classes.ui.religion.TransformBtnController", com.nuclearunicorn.ga
 	},
 
 	buyItem: function(model, event, callback) {
-		if (model.enabled && this.hasResources(model)) {
-			var batchSize = event.shiftKey ? 10000 :
-				event.ctrlKey || event.metaKey ? this.game.opts.batchSize : 1;
-			callback(this._transform(model, batchSize));
+		if (!this.hasResources(model)) {
+			callback({ itemBought: false, reason: "cannot-afford" });
+			return;
 		}
-		callback(false);
+		if (!model.enabled) {
+			callback({ itemBought: false, reason: "not-enabled" });
+			return;
+		}
+		var batchSize = event.shiftKey ? 10000 :
+			event.ctrlKey || event.metaKey ? this.game.opts.batchSize : 1;
+		var didWeSucceed = this._transform(model, batchSize);
+		if (didWeSucceed) {
+			callback({ itemBought: true, reason: "paid-for" });
+		} else {
+			//_transform(model, amt) returns false if we can't afford it
+			callback({ itemBought: false, reason: "cannot-afford" });
+		}
 	},
 
 	_canAfford: function(model) {
@@ -1385,10 +1396,21 @@ dojo.declare("classes.ui.religion.TransformBtnController", com.nuclearunicorn.ga
 
 	transform: function(model, divider, event, callback) {
 		var amt = Math.floor(this._canAfford(model) / divider);
-		if (model.enabled && amt >= 1) {
-			callback(this._transform(model, amt));
+		if (amt < 1) {
+			callback({ itemBought: false, reason: "cannot-afford" });
+			return;
 		}
-		callback(false);
+		if (!model.enabled) {
+			callback({ itemBought: false, reason: "not-enabled" });
+			return;
+		}
+		var didWeSucceed = this._transform(model, amt);
+		if (didWeSucceed) {
+			callback({ itemBought: true, reason: "paid-for" });
+		} else {
+			//_transform(model, amt) returns false if we can't afford it
+			callback({ itemBought: false, reason: "cannot-afford" });
+		}
 	},
 
 	_transform: function(model, amt) {
@@ -1470,25 +1492,29 @@ dojo.declare("classes.ui.religion.RefineTearsBtnController", com.nuclearunicorn.
 	},
 
 	buyItem: function(model, event, callback, count){
-		if (model.enabled && this.hasResources(model)) {
-			if (this.game.resPool.get("sorrow").value >= this.game.resPool.get("sorrow").maxValue){
-				this.game.msg($I("religion.refineTearsBtn.refine.msg.failure"));
-				callback(false);
-				return;
-			}
-
-			for (var batchSize = count || (event.ctrlKey ? this.game.opts.batchSize : 1);
-				 batchSize > 0
-				 && this.hasResources(model)
-				 && this.game.resPool.get("sorrow").value < this.game.resPool.get("sorrow").maxValue;
-				 batchSize--) {
-				this.payPrice(model);
-				this.refine();
-			}
-
-			callback(true);
+		if (!this.hasResources(model)) {
+			callback({ itemBought: false, reason: "cannot-afford" });
+			return;
 		}
-		callback(false);
+		if (!model.enabled) {
+			callback({ itemBought: false, reason: "not-enabled" });
+			return;
+		}
+		if (this.game.resPool.get("sorrow").value >= this.game.resPool.get("sorrow").maxValue){
+			//We can't refine because we're at the limit.
+			this.game.msg($I("religion.refineTearsBtn.refine.msg.failure"));
+			callback({ itemBought: false, reason: "already-bought" });
+			return;
+		}
+		for (var batchSize = count || (event.ctrlKey ? this.game.opts.batchSize : 1);
+			 batchSize > 0
+			 && this.hasResources(model)
+			 && this.game.resPool.get("sorrow").value < this.game.resPool.get("sorrow").maxValue;
+			 batchSize--) {
+			this.payPrice(model);
+			this.refine();
+		}
+		callback({ itemBought: true, reason: "paid-for" });
 	},
 
 	refine: function(){
@@ -1585,15 +1611,16 @@ dojo.declare("classes.ui.PactsPanel", com.nuclearunicorn.game.ui.Panel, {
 	buyItem: function(model, event, callback) {
 		this.game.updateCaches();
 		this.updateEnabled(model);
-		if ((this.hasResources(model)) || this.game.devMode){
-			if(!this.shouldBeBough(model, this.game)){
-				callback(false);
-				return;
-			}
-			this._buyItem_step2(model, event, callback);
-		}else{
-			callback(false);
+
+		if (!this.hasResources(model) && !this.game.devMode) {
+			callback({ itemBought: false, reason: "cannot-afford" });
+			return;
 		}
+		if(!this.shouldBeBough(model, this.game)){
+			callback({ itemBought: false, reason: "already-bought" /*No more pacts available*/ });
+			return;
+		}
+		this._buyItem_step2(model, event, callback);
 	},
 
 	build: function(model, maxBld){

--- a/js/religion.js
+++ b/js/religion.js
@@ -1376,6 +1376,8 @@ dojo.declare("classes.ui.religion.TransformBtnController", com.nuclearunicorn.ga
 			return;
 		}
 		if (!model.enabled) {
+			//As far as I can tell, this shouldn't ever happen because being
+			//unable to afford it is the only reason for it to be disabled.
 			callback({ itemBought: false, reason: "not-enabled" });
 			return;
 		}
@@ -1401,6 +1403,8 @@ dojo.declare("classes.ui.religion.TransformBtnController", com.nuclearunicorn.ga
 			return;
 		}
 		if (!model.enabled) {
+			//As far as I can tell, this shouldn't ever happen because being
+			//unable to afford it is the only reason for it to be disabled.
 			callback({ itemBought: false, reason: "not-enabled" });
 			return;
 		}
@@ -1497,6 +1501,8 @@ dojo.declare("classes.ui.religion.RefineTearsBtnController", com.nuclearunicorn.
 			return;
 		}
 		if (!model.enabled) {
+			//As far as I can tell, this shouldn't ever happen because being
+			//unable to afford it is the only reason for it to be disabled.
 			callback({ itemBought: false, reason: "not-enabled" });
 			return;
 		}

--- a/js/science.js
+++ b/js/science.js
@@ -1874,43 +1874,50 @@ dojo.declare("classes.ui.PolicyBtnController", com.nuclearunicorn.game.ui.Buildi
 		}
 	},
 
-	shouldBeBough: function(model, game){ //fail checks:
+	//Returns an object with two fields:
+	//	itemBought:	Boolean.  Are we able to buy this policy at this time?
+	//	reason:		String.  If we can't buy it, why not?  If we can buy it, returns
+	//				"paid-for" regardless of whether we can actually afford it or not.
+	shouldBeBought: function(model, game){ //fail checks:
 		if(this.game.village.leader && model.metadata.requiredLeaderJob && this.game.village.leader.job != model.metadata.requiredLeaderJob){
 			var jobTitle = this.game.village.getJob(model.metadata.requiredLeaderJob).title;
 			this.game.msg($I("msg.policy.wrongLeaderJobForResearch", [model.metadata.label, jobTitle]), "important");
-			return false;
+			return { itemBought: false, reason: "blocked" };
 		}else if(model.metadata.name == "transkittenism" && this.game.bld.getBuildingExt("aiCore").meta.effects["aiLevel"] >= 15){
 			this.game.msg($I("msg.policy.aiNotMerges"),"alert", "ai");
-			return false;
+			return { itemBought: false, reason: "blocked" };
 		}else if(model.metadata.blocked != true) {
              for(var i = 0; i < model.metadata.blocks.length; i++){
                 if(this.game.science.getPolicy(model.metadata.blocks[i]).researched){
                     model.metadata.blocked = true;
-                    return false;
+				return { itemBought: false, reason: "blocked" };
                 }
 			}
 			var confirmed = false; //confirmation:
 			if(game.opts.noConfirm){
-				return true;
+				return { itemBought: true, reason: "paid-for" };
 			}
 			game.ui.confirm($I("policy.confirmation.title"), $I("policy.confirmation.title"), function() {
 				confirmed = true;
 			});
+			return confirmed ? { itemBought: true, reason: "paid-for" } : { itemBought: false, reason: "player-denied" };
 		}
-		return confirmed;
+		//Else, the policy was blocked:
+		return { itemBought: false, reason: "blocked" };
 	},
 	buyItem: function(model, event, callback) {
 		var isInDevMode = this.game.devMode;
-		if (!this.hasResources(model) && !isInDevMode) {
-			callback({ itemBought: false, reason: "cannot-afford" });
-			return;
-		}
 		if (model.metadata.researched && !isInDevMode) {
 			callback({ itemBought: false, reason: "already-bought" });
 			return;
 		}
-		if(!this.shouldBeBough(model, this.game)){
-			callback({ itemBought: false, reason: "*sigh* there are many reasons why you would be unable to purchase a policy & I cannot list them all here" });
+		if (!this.hasResources(model) && !isInDevMode) {
+			callback({ itemBought: false, reason: "cannot-afford" });
+			return;
+		}
+		var result = this.shouldBeBought(model, this.game);
+		if(!result.itemBought){
+			callback(result); //Tell them *why* we failed to buy the item.
 			return;
 		}
 		this.payPrice(model);

--- a/js/science.js
+++ b/js/science.js
@@ -1900,20 +1900,23 @@ dojo.declare("classes.ui.PolicyBtnController", com.nuclearunicorn.game.ui.Buildi
 		return confirmed;
 	},
 	buyItem: function(model, event, callback) {
-		if ((!model.metadata.researched && this.hasResources(model)) || this.game.devMode){
-			if(!this.shouldBeBough(model, this.game)){
-				callback(false);
-				return;
-			}
-			this.payPrice(model);
-
-			this.onPurchase(model);
-
-			callback(true);
-			this.game.render();
+		var isInDevMode = this.game.devMode;
+		if (!this.hasResources(model) && !isInDevMode) {
+			callback({ itemBought: false, reason: "cannot-afford" });
 			return;
 		}
-		callback(false);
+		if (model.metadata.researched && !isInDevMode) {
+			callback({ itemBought: false, reason: "already-bought" });
+			return;
+		}
+		if(!this.shouldBeBough(model, this.game)){
+			callback({ itemBought: false, reason: "*sigh* there are many reasons why you would be unable to purchase a policy & I cannot list them all here" });
+			return;
+		}
+		this.payPrice(model);
+		this.onPurchase(model);
+		callback({ itemBought: true, reason: (this.game.devMode ? "dev-mode" : "paid-for") });
+		this.game.render();
 	},
 	onPurchase: function(model){
 		this.inherited(arguments);

--- a/js/space.js
+++ b/js/space.js
@@ -1304,7 +1304,7 @@ dojo.declare("com.nuclearunicorn.game.ui.SpaceProgramBtnController", com.nuclear
 		if (model.metadata.val == 0) {
 			this.inherited(arguments);
 		} else {
-			callback(false);
+			callback({ itemBought: false, reason: "already-bought" });
 		}
 	},
 

--- a/js/time.js
+++ b/js/time.js
@@ -2010,10 +2010,14 @@ dojo.declare("classes.queue.manager", null,{
                 for (var i in voidSpaceUpgrades){
                     var building = voidSpaceUpgrades[i];
                     if(building.name == "usedCryochambers"){
-                        options.push({
-                            name: building.name,
-                            label: $I("time.fixCryochambers.label")
-                        });
+                        //ONLY allow queueing of Fix Cryochamber if we have unlocked that feature normally.
+                        if (this.game.workshop.get("chronoforge").researched && building.val != 0)
+                        {
+                            options.push({
+                                name: building.name,
+                                label: $I("time.fixCryochambers.label")
+                            });
+                        }
                         continue;
                     }
                     if (building.unlocked){

--- a/js/time.js
+++ b/js/time.js
@@ -1779,7 +1779,7 @@ dojo.declare("classes.queue.manager", null,{
             value: 1    //always store size of the queue group, even if it is a single item
         });
 
-        if (shiftKey && !this.queueNonStabkable.includes(type)){
+        if (shiftKey && !this.queueNonStackable.includes(type)){
             while(this.queueLength() < this.cap){
                 this.addToQueue(name, type, label, false);
             }

--- a/js/time.js
+++ b/js/time.js
@@ -2262,9 +2262,8 @@ dojo.declare("classes.queue.manager", null,{
                 break;
 
             case "spaceMission":
-                compare = "reached";
                 props.controller = new com.nuclearunicorn.game.ui.SpaceProgramBtnController(this.game);
-                var oldVal = itemMetaRaw.researched;
+                var oldVal = itemMetaRaw.val;
                 var model = props.controller.fetchModel(props);
                 break;
 
@@ -2356,14 +2355,15 @@ dojo.declare("classes.queue.manager", null,{
             //console.log( "Successfully built " + el.name + " using the queue." );
         } else {
             //console.log( "Tried to build " + el.name + " using the queue, but failed." );
-        }
-
-        if(compare == "research" || compare == "reached" && model.metadata[compare] == true
-            || (compare.includes("blocked") && model.metadata["blocked"] == true) ||
-            (compare.includes("research") && model.metadata["research"] == true)
-        ){
-            this.dropLastItem();
-            this.game._publish("ui/update", this.game);
+            if( (compare == "researched" && model.metadata[compare] == true ) ||
+                (compare.includes("blocked") && model.metadata["blocked"] == true) ||
+                (compare.includes("researched") && model.metadata["researched"] == true) ||
+                (el.type === "spaceMission" && model.metadata[compare])
+            ){
+                this.dropLastItem();
+                this.game._publish("ui/update", this.game);
+                //console.log( "Dropped " + el.name + " from the queue because it can't be built anymore." );
+            }
         }
     }
 });

--- a/js/time.js
+++ b/js/time.js
@@ -137,6 +137,8 @@ dojo.declare("classes.managers.TimeManager", com.nuclearunicorn.core.TabManager,
 			var bld = this.voidspaceUpgrades[i];
 			this.resetStateStackable(bld);
 		}
+
+        this.queue.resetState();
     },
 
     update: function(){
@@ -1738,6 +1740,14 @@ dojo.declare("classes.queue.manager", null,{
     constructor: function(game){
         this.game = game;
         
+    },
+
+    resetState: function() {
+        this.cap = this.baseCap;
+        this.alphabeticalSort = true;
+        this.queueItems = [];
+        this.queueSources = dojo.clone(this.queueSourcesDefault);
+        this.queueSourcesArr = [{name: "buildings", label: $I("buildings.tabName")}];
     },
 
     /**

--- a/js/time.js
+++ b/js/time.js
@@ -2167,39 +2167,31 @@ dojo.declare("classes.queue.manager", null,{
 
             case "zigguratUpgrades":
                 props.controller = new com.nuclearunicorn.game.ui.ZigguratBtnController(this.game);
-                //var oldVal = itemMetaRaw.val;
                 var model = props.controller.fetchModel(props);
                 break;
 
             case "religion":
                 props.controller = new com.nuclearunicorn.game.ui.ReligionBtnController(this.game);
-                //var oldVal = itemMetaRaw.val;
                 var model = props.controller.fetchModel(props);
                 break;
 
             case "transcendenceUpgrades":
                 props.controller = new classes.ui.TranscendenceBtnController(this.game);
-                //var oldVal = itemMetaRaw.val;
                 var model = props.controller.fetchModel(props);
                 break;
 
             case "pacts":
                 props.controller = new com.nuclearunicorn.game.ui.PactsBtnController(this.game);
-                //var oldVal = itemMetaRaw.val;
                 var model = props.controller.fetchModel(props);
                 break;
 
             case "upgrades":
-                //compare = "researched";
                 props.controller = new com.nuclearunicorn.game.ui.UpgradeButtonController(this.game);
-                //var oldVal = itemMetaRaw.researched;
                 var model = props.controller.fetchModel(props);
                 break;
 
             case "zebraUpgrades":
-                //compare = "researched";
                 props.controller = new com.nuclearunicorn.game.ui.ZebraUpgradeButtonController(this.game);
-                //var oldVal = itemMetaRaw.researched;
                 var model = props.controller.fetchModel(props);
                 break;
         }
@@ -2211,7 +2203,6 @@ dojo.declare("classes.queue.manager", null,{
             return;
         }
         var el = this.queueItems[0];
-
         if (!el){
             console.warn("null queue item, skipping");
             this.queueItems.shift();
@@ -2219,161 +2210,59 @@ dojo.declare("classes.queue.manager", null,{
             return;
         }
 
-        var itemMetaRaw = this.game.getUnlockByName(el.name, el.type);
-        var compare = "val"; //we should do some sort of refractoring of the switch mechanism
-
-        if (!itemMetaRaw){
-            console.error("invalid queue item:", el);
+        var controllerAndModel = this.getQueueElementControllerAndModel(el);
+        if(!controllerAndModel || !controllerAndModel.controller || !controllerAndModel.model){
+            console.error(el.name + " of " + el.type + " queing is not supported!");
+            this.queueItems.shift();
+            this.game._publish("ui/update", this.game);
             return;
         }
 
-        var props = {
-            id: itemMetaRaw.name
-        };
-        var buyItem = true;
+        var resultOfBuyingItem = null;
+        //TODO: use null event instead of empty object
+        controllerAndModel.controller.buyItem(controllerAndModel.model, {}, function(args) { resultOfBuyingItem = args; });
 
-        switch (el.type){
-            case "policies":
-                compare = ["researched", "blocked"];
-                props.controller = new classes.ui.PolicyBtnController(this.game);
-                var oldVal = {
-                    researched: itemMetaRaw.researched,
-                    blocked: itemMetaRaw.blocked
-                };
-                var model = props.controller.fetchModel(props);
-                break;
-                
-            case "tech":
-                compare = "researched";
-                props.controller = new com.nuclearunicorn.game.ui.TechButtonController(this.game);
-                var oldVal = itemMetaRaw.researched;
-                var model = props.controller.fetchModel(props);
-                break;
-
-            case "buildings":
-                var bld = new classes.BuildingMeta(itemMetaRaw).getMeta();
-                    oldVal = itemMetaRaw.val;
-                props = {
-                    key:            bld.name,
-                    name:           bld.label,
-                    description:    bld.description,
-                    building:       bld.name
-                };
-                if (typeof(bld.stages) == "object"){
-                    props.controller = new classes.ui.btn.StagingBldBtnController(this.game);
-                } else {
-                    props.controller = new classes.ui.btn.BuildingBtnModernController(this.game);
-                }
-                var model = props.controller.fetchModel(props);
-                //props.controller.build(model, 1);
-                //buyItem = false;
-                break;
-
-            case "spaceMission":
-                props.controller = new com.nuclearunicorn.game.ui.SpaceProgramBtnController(this.game);
-                var oldVal = itemMetaRaw.val;
-                var model = props.controller.fetchModel(props);
-                break;
-
-            case "spaceBuilding":
-                props.controller = new classes.ui.space.PlanetBuildingBtnController(this.game);
-                var oldVal = itemMetaRaw.val;
-                var model = props.controller.fetchModel(props);
-                break;
-
-            case "chronoforge":
-                props.controller = new classes.ui.time.ChronoforgeBtnController(this.game);
-                var oldVal = itemMetaRaw.val;
-                var model = props.controller.fetchModel(props);
-                break;
-
-            case "voidSpace":
-                props.controller = new classes.ui.time.VoidSpaceBtnController(this.game);
-                var oldVal = itemMetaRaw.val;
-                var model = props.controller.fetchModel(props);
-                if(el.name == "usedCryochambers"){ //a bunch of model black magic
-                    props.controller = new classes.ui.time.FixCryochamberBtnController(this.game);
-                    itemMetaRaw = this.game.getUnlockByName("cryochambers", el.type);
-                    model.prices = this.game.time.getVSU("usedCryochambers").fixPrices;
-                    model.enabled = this.game.resPool.hasRes(model.prices); //check we actually have enough to do one fix!
-                    //console.log(model);
-                }
-                break;
-
-            case "zigguratUpgrades":
-                props.controller = new com.nuclearunicorn.game.ui.ZigguratBtnController(this.game);
-                var oldVal = itemMetaRaw.val;
-                var model = props.controller.fetchModel(props);
-                break;
-
-            case "religion":
-                props.controller = new com.nuclearunicorn.game.ui.ReligionBtnController(this.game);
-                var oldVal = itemMetaRaw.val;
-                var model = props.controller.fetchModel(props);
-                break;
-
-            case "transcendenceUpgrades":
-                props.controller = new classes.ui.TranscendenceBtnController(this.game);
-                var oldVal = itemMetaRaw.val;
-                var model = props.controller.fetchModel(props);
-                break;
-
-            case "pacts":
-                props.controller = new com.nuclearunicorn.game.ui.PactsBtnController(this.game);
-                var oldVal = itemMetaRaw.val;
-                var model = props.controller.fetchModel(props);
-                break;
-
-            case "upgrades":
-                compare = "researched";
-                props.controller = new com.nuclearunicorn.game.ui.UpgradeButtonController(this.game);
-                var oldVal = itemMetaRaw.researched;
-                var model = props.controller.fetchModel(props);
-                break;
-
-            case "zebraUpgrades":
-                compare = "researched";
-                props.controller = new com.nuclearunicorn.game.ui.ZebraUpgradeButtonController(this.game);
-                var oldVal = itemMetaRaw.researched;
-                var model = props.controller.fetchModel(props);
-                break;
+        if (typeof(resultOfBuyingItem) !== "object" || !resultOfBuyingItem) {
+            console.error("Invalid result after attempting to buy item via queue", resultOfBuyingItem);
+            return;
         }
-        
-        if(!props.controller){
-            console.error(el.name + " of " + el.type + " queing is not supported!");
-            var deletedElement = this.queueItems.shift();
-            this.game._publish("ui/update", this.game);
-        }
-        var resultOfBuyingItem;
-        if(buyItem){
-            props.controller.buyItem(model, 1, function(args) { resultOfBuyingItem = args; });
-        }
-        var changed = false;
-        if (Array.isArray(compare)){
-            for (var i in compare){
-                if (oldVal[compare[i]] != model.metadata[compare[i]]){
-                    changed = true;
-                }
-            }
-        }else{
-            changed = oldVal != model.metadata[compare];
-        }
-        if(changed){
+
+        var reason = resultOfBuyingItem.reason; //String explaining *why* we failed to buy the item
+
+        //Depending on the result, do something different:
+        if (resultOfBuyingItem.itemBought){
+            //Item successfully purchased!  Remove it from the queue because we did it :D
             this.dropLastItem();
             this.game._publish("ui/update", this.game);
-            //console.log( "Successfully built " + el.name + " using the queue." );
+            console.log("Successfully built " + el.name + " using the queue because " + reason);
         } else {
-            //console.log( "Tried to build " + el.name + " using the queue, but failed." );
-            if( (compare == "researched" && model.metadata[compare] == true ) ||
-                (compare.includes("blocked") && model.metadata["blocked"] == true) ||
-                (compare.includes("researched") && model.metadata["researched"] == true) ||
-                (el.type === "spaceMission" && model.metadata[compare])
-            ){
+            if (this._isReasonToSkipItem(reason)) {
                 this.dropLastItem();
                 this.game._publish("ui/update", this.game);
-                //console.log( "Dropped " + el.name + " from the queue because it can't be built anymore." );
+                console.log("Dropped " + el.name + " from the queue because " + reason);
+            } else {
+                console.log("Tried to build " + el.name + " using the queue, but failed because " + reason);
             }
         }
+    },
+
+    //Determines whether or not we should silently remove an item from the queue
+    //based on the reason WHY we can't buy it.
+    //@param reason     String containing a code passed to the callback function
+    //@return           Boolean.  If true, the item should be removed from the queue.
+    //                  If false, the queue should wait until we are able to purchase the item.
+    _isReasonToSkipItem: function(reason) {
+        if (reason == "paid-for" || reason == "item-is-free" || reason == "dev-mode") {
+            //These are used as reasons why we DID purchase the item.
+            //If we DID purchase the item, of course we want it removed from the queue!
+            return true;
+        }
+        if (reason == "already-bought" || reason == "player-denied") {
+            //These are good reasons the queue should skip over the item entirely.
+            return true;
+        }
+        //Else, most likely we just can't afford the item yet.
+        return false;
     },
 
     //This function is to be called whenever a building is deltagraded.

--- a/js/time.js
+++ b/js/time.js
@@ -1417,7 +1417,12 @@ dojo.declare("classes.ui.time.FixCryochamberBtnController", com.nuclearunicorn.g
 
 	updateVisible: function(model) {
 		model.visible = this.game.workshop.get("chronoforge").researched && this.game.time.getVSU("usedCryochambers").val != 0;
-	}
+	},
+
+    //This is a bit of a hack to get the correct description to appear in the queue tooltips...
+    getDescription: function(model) {
+        return $I("time.fixCryochambers.desc");
+    }
 });
 
 dojo.declare("classes.ui.VoidSpaceWgt", [mixin.IChildrenAware, mixin.IGameAware], {
@@ -2083,7 +2088,13 @@ dojo.declare("classes.queue.manager", null,{
         this.dropLastItem();
         this.showList();
     },
-    getQueueElementModel: function(el){
+    getQueueElementModel: function(el) {
+        var controllerAndModel = this.getQueueElementControllerAndModel(el);
+        if (controllerAndModel) {
+            return controllerAndModel.model;
+        }
+    },
+    getQueueElementControllerAndModel: function(el){
         var itemMetaRaw = this.game.getUnlockByName(el.name, el.type);
         if (!itemMetaRaw){
             console.error("invalid queue item:", el);
@@ -2142,7 +2153,7 @@ dojo.declare("classes.queue.manager", null,{
                     itemMetaRaw = this.game.getUnlockByName("cryochambers", el.type);
                     model.prices = this.game.time.getVSU("usedCryochambers").fixPrices;
                     model.enabled = this.game.resPool.hasRes(model.prices); //check we actually have enough to do one fix!
-                    console.log(model);
+                    //console.log(model);
                 }
                 break;
 
@@ -2184,8 +2195,7 @@ dojo.declare("classes.queue.manager", null,{
                 var model = props.controller.fetchModel(props);
                 break;
         }
-        //return props, model;
-        return model;
+        return { controller: props.controller, model: model };
     },
     update: function(){
         this.cap = this.calculateCap();
@@ -2279,7 +2289,7 @@ dojo.declare("classes.queue.manager", null,{
                     itemMetaRaw = this.game.getUnlockByName("cryochambers", el.type);
                     model.prices = this.game.time.getVSU("usedCryochambers").fixPrices;
                     model.enabled = this.game.resPool.hasRes(model.prices); //check we actually have enough to do one fix!
-                    console.log(model);
+                    //console.log(model);
                 }
                 break;
 

--- a/js/time.js
+++ b/js/time.js
@@ -2252,14 +2252,14 @@ dojo.declare("classes.queue.manager", null,{
             //Item successfully purchased!  Remove it from the queue because we did it :D
             this.dropLastItem();
             this.game._publish("ui/update", this.game);
-            console.log("Successfully built " + el.name + " using the queue because " + reason);
+            //console.log("Successfully built " + el.name + " using the queue because " + reason);
         } else {
             if (this._isReasonToSkipItem(reason)) {
                 this.dropLastItem();
                 this.game._publish("ui/update", this.game);
-                console.log("Dropped " + el.name + " from the queue because " + reason);
+                //console.log("Dropped " + el.name + " from the queue because " + reason);
             } else {
-                console.log("Tried to build " + el.name + " using the queue, but failed because " + reason);
+                //console.log("Tried to build " + el.name + " using the queue, but failed because " + reason);
             }
         }
     },

--- a/js/time.js
+++ b/js/time.js
@@ -1396,6 +1396,7 @@ dojo.declare("classes.ui.time.FixCryochamberBtnController", com.nuclearunicorn.g
 			return;
         }
 
+		if (!event) { event = {}; /*event is an optional parameter*/ }
 		var fixCount = event.shiftKey
 			? 1000
 			: event.ctrlKey || event.metaKey /*osx tears*/
@@ -2237,8 +2238,7 @@ dojo.declare("classes.queue.manager", null,{
         }
 
         var resultOfBuyingItem = null;
-        //TODO: use null event instead of empty object
-        controllerAndModel.controller.buyItem(controllerAndModel.model, {}, function(args) { resultOfBuyingItem = args; });
+        controllerAndModel.controller.buyItem(controllerAndModel.model, null, function(args) { resultOfBuyingItem = args; });
 
         if (typeof(resultOfBuyingItem) !== "object" || !resultOfBuyingItem) {
             console.error("Invalid result after attempting to buy item via queue", resultOfBuyingItem);

--- a/js/time.js
+++ b/js/time.js
@@ -2365,5 +2365,27 @@ dojo.declare("classes.queue.manager", null,{
                 //console.log( "Dropped " + el.name + " from the queue because it can't be built anymore." );
             }
         }
+    },
+
+    //This function is to be called whenever a building is deltagraded.
+    //This function iterates through all queue items with the same internal ID as the
+    //deltagraded building & updates their labels to match the new version.
+    //@param itemName   String.  The ID of whichever building was deltagraded.
+    onDeltagrade: function(itemName) {
+        var buildingsManager = this.game.bld;
+        dojo.forEach(this.queueItems, function(item) {
+            if(!item || item.name !== itemName) {
+                return;
+            }
+            //Else, we have here a valid queue item matching the name of what was deltagraded.
+            if(item.type === "buildings") {
+                var building = buildingsManager.getBuildingExt(itemName).meta;
+                var newLabel = building.label;
+                if(building.stages){
+                    newLabel = building.stages[building.stage].label;
+                }
+                item.label = newLabel;
+            }
+        });
     }
 });

--- a/js/workshop.js
+++ b/js/workshop.js
@@ -2908,8 +2908,12 @@ dojo.declare("com.nuclearunicorn.game.ui.CraftButtonController", com.nuclearunic
 	},
 
 	buyItem: function(model, event, callback) {
-		this.game.workshop.craft(model.craft.name, 1);
-		callback(true);
+		var wasCraftSuccessful = this.game.workshop.craft(model.craft.name, 1);
+		if (wasCraftSuccessful) {
+			callback({ itemBought: true, reason: "paid-for" });
+		} else {
+			callback({ itemBought: false, reason: "cannot-afford" });
+		}
 	}
 });
 

--- a/test/game.test.js
+++ b/test/game.test.js
@@ -419,6 +419,32 @@ test("Queue should correctly add and remove items", () => {
     expect(queue.queueItems[1].value).toBe(11);
 });
 
+test("Queue should correctly skip one-time purchases if already bought", () => {
+    let queue = game.time.queue;
+
+    //The queue should skip techs that are already researched:
+    game.science.get("calendar").researched = true;
+    game.resPool.get("science").value = 30; //Enough to purchase the Calendar tech.
+    queue.addToQueue("calendar", "tech", "N/A");
+    expect(queue.queueLength()).toBe(1);
+    queue.update();
+    expect(queue.queueLength()).toBe(0);
+    expect(game.resPool.get("science").value).toBe(30); //We didn't spend any science because we skipped the item
+
+    //The queue should skip both researched & blocked policies:
+    game.science.getPolicy("liberty").researched = true;
+    game.science.getPolicy("tradition").blocked = true;
+    game.resPool.get("culture").value = 150; //Enough to purchase either policy.
+    queue.addToQueue("liberty", "policies", "N/A");
+    queue.addToQueue("tradition", "policies", "N/A");
+    expect(queue.queueLength()).toBe(2);
+    queue.update();
+    expect(queue.queueLength()).toBe(1);
+    queue.update();
+    expect(queue.queueLength()).toBe(0);
+    expect(game.resPool.get("culture").value).toBe(150);
+});
+
 //--------------------------------
 //      Spaceport test
 //--------------------------------
@@ -447,4 +473,367 @@ test("Spaceports should be unlocked correctly and have a custom price logic appl
     expect(Math.round(_get("warehouse").prices.find(price => price.name == "titanium").val)).toBe(40456);
     //starchart price should skyroket due to the custom price ratio
     expect(Math.round(_get("warehouse").prices.find(price => price.name == "starchart").val)).toBe(8134223);
+});
+
+//--------------------------------
+//      buyItem internals
+//--------------------------------
+test("buyItem internals should work properly for Resource Retrieval", () => {
+    const controller = new classes.ui.time.ChronoforgeBtnController(game);
+    const model = controller.fetchModel({ id: "ressourceRetrieval" });
+    let callbackResult = null;
+    const callbackFunction = function(result) { callbackResult = result; };
+
+    //Before we get started, this test assumes certain things about Resource Retrievals:
+    //We assume there is a limit of 100.
+    //We assume the first one costs 1000 time crystals (TCs).
+    //We assume the price ratio is 1.3.
+    //Resource Retrievals should be representative of most buildings in the game, plus it has the unique limitBuild feature.
+
+    //Try buying an item, but we have 0 TCs so it should fail:
+    controller.updateEnabled(model);
+    controller.buyItem(model, null, callbackFunction);
+    expect(model.metadata.on).toBe(0);
+    expect(model.metadata.val).toBe(0);
+    expect(callbackResult).toHaveProperty("itemBought", false);
+    expect(callbackResult).toHaveProperty("reason", "cannot-afford");
+
+    //Enter dev mode:
+    game.devMode = true;
+    controller.updateEnabled(model);
+    controller.buyItem(model, null, callbackFunction);
+    expect(model.metadata.on).toBe(1);
+    expect(model.metadata.val).toBe(1);
+    expect(callbackResult).toHaveProperty("itemBought", true);
+    expect(callbackResult).toHaveProperty("reason", "dev-mode");
+
+    //Now exit dev mode & try to buy the next building legitimately.
+    game.devMode = false;
+    game.resPool.get("timeCrystal").value = 1350; //Enough for 1, with some spare change
+    controller.updateEnabled(model); //After we gain the resources, there'd usually be a UI update that calls this
+    controller.buyItem(model, null, callbackFunction);
+    expect(game.resPool.get("timeCrystal").value).toBe(50);
+    expect(model.metadata.on).toBe(2);
+    expect(model.metadata.val).toBe(2);
+    expect(callbackResult).toHaveProperty("itemBought", true);
+    expect(callbackResult).toHaveProperty("reason", "paid-for");
+
+    //Test that holding the CTRL key builds batchSize of the item.
+    //Along the way, we'll test that the price updated properly.
+    game.opts.batchSize = 6;
+    game.resPool.get("timeCrystal").value = 100000; //Way more than needed
+    controller.updateEnabled(model);
+    controller.buyItem(model, { ctrlKey: true, shiftKey: false }, callbackFunction);
+    expect(game.resPool.get("timeCrystal").value).toBeCloseTo(78442.3093, 4);
+    expect(model.metadata.on).toBe(8);
+    expect(model.metadata.val).toBe(8);
+    expect(callbackResult).toHaveProperty("itemBought", true);
+    expect(callbackResult).toHaveProperty("reason", "paid-for");
+
+    //Test that holding the SHIFT key builds as many of the item as you can afford & overrides CTRL key.
+    game.opts.noConfirm = true;
+    game.resPool.get("timeCrystal").value = 1000000; //Enough to go from 8 to 21 buildings.
+    controller.updateEnabled(model);
+    controller.buyItem(model, { ctrlKey: true, shiftKey: true }, callbackFunction);
+    expect(model.metadata.on).toBe(21);
+    expect(model.metadata.val).toBe(21);
+    expect(game.resPool.get("timeCrystal").value).toBeCloseTo(203642.5938, 4);
+    expect(callbackResult).toHaveProperty("itemBought", true);
+    expect(callbackResult).toHaveProperty("reason", "paid-for");
+
+    //Test that we get the same result no matter the event parameters if we can't afford any.
+    //We'll test each combination of 2 Boolean parameters for a total of 2^2 = 4 combinations
+    controller.updateEnabled(model);
+    controller.buyItem(model, { ctrlKey: true, shiftKey: true }, callbackFunction);     //11
+    expect(callbackResult).toHaveProperty("itemBought", false);
+    expect(callbackResult).toHaveProperty("reason", "cannot-afford");
+    controller.updateEnabled(model);
+    controller.buyItem(model, { ctrlKey: false, shiftKey: true }, callbackFunction);    //01
+    expect(callbackResult).toHaveProperty("itemBought", false);
+    expect(callbackResult).toHaveProperty("reason", "cannot-afford");
+    controller.updateEnabled(model);
+    controller.buyItem(model, { ctrlKey: true, shiftKey: false }, callbackFunction);    //10
+    expect(callbackResult).toHaveProperty("itemBought", false);
+    expect(callbackResult).toHaveProperty("reason", "cannot-afford");
+    controller.updateEnabled(model);
+    controller.buyItem(model, { ctrlKey: false, shiftKey: false }, callbackFunction);   //00
+    expect(callbackResult).toHaveProperty("itemBought", false);
+    expect(callbackResult).toHaveProperty("reason", "cannot-afford");
+
+    //Double-check that nothing was built in any of those 4 tests:
+    expect(model.metadata.on).toBe(21);
+    expect(model.metadata.val).toBe(21);
+
+    //Test that if we have unlimited resources, we only build up to the limit.
+    game.resPool.get("timeCrystal").value = Infinity;
+    controller.updateEnabled(model);
+    controller.buyItem(model, { ctrlKey: false, shiftKey: true }, callbackFunction);
+    expect(model.metadata.on).toBe(100);
+    expect(model.metadata.val).toBe(100);
+    expect(callbackResult).toHaveProperty("itemBought", true);
+    expect(callbackResult).toHaveProperty("reason", "paid-for");
+
+    //Test that we can't buy any more even if we have unlimited resources.
+    controller.updateEnabled(model);
+    controller.buyItem(model, null, callbackFunction);
+    expect(model.metadata.on).toBe(100);
+    expect(model.metadata.val).toBe(100);
+    expect(callbackResult).toHaveProperty("itemBought", false);
+    expect(callbackResult).toHaveProperty("reason", "already-bought");
+});
+
+test("buyItem internals should work properly for Calendar", () => {
+    const controller = new com.nuclearunicorn.game.ui.TechButtonController(game);
+    const model = controller.fetchModel({ id: "calendar" });
+    let callbackResult = null;
+    const callbackFunction = function(result) { callbackResult = result; };
+
+    //Before we get started, this test assumes certain things about Calendar:
+    //We assume it costs 30 science.
+    //Calendar should be representative of most techs & upgrades in the game.
+
+    //Try buying an item, but we have 0 science so it should fail:
+    controller.updateEnabled(model);
+    controller.buyItem(model, null, callbackFunction);
+    expect(model.metadata.researched).toBe(false);
+    expect(callbackResult).toHaveProperty("itemBought", false);
+    expect(callbackResult).toHaveProperty("reason", "cannot-afford");
+
+    //Give ourselves plenty of science & try again; this time it should succeed:
+    game.resPool.get("science").value = 100;
+    controller.updateEnabled(model);
+    controller.buyItem(model, null, callbackFunction);
+    expect(model.metadata.researched).toBe(true);
+    expect(callbackResult).toHaveProperty("itemBought", true);
+    expect(callbackResult).toHaveProperty("reason", "paid-for");
+    expect(game.resPool.get("science").value).toBe(70);
+
+    //Try again; this time it should fail because already bought:
+    controller.updateEnabled(model);
+    controller.buyItem(model, null, callbackFunction);
+    expect(model.metadata.researched).toBe(true);
+    expect(callbackResult).toHaveProperty("itemBought", false);
+    expect(callbackResult).toHaveProperty("reason", "already-bought");
+    expect(game.resPool.get("science").value).toBe(70);
+});
+
+test("buyItem internals should work properly for Liberty & Tradition", () => {
+    const controller = new classes.ui.PolicyBtnController(game);
+    let model = controller.fetchModel({ id: "liberty" });
+    let callbackResult = null;
+    const callbackFunction = function(result) { callbackResult = result; };
+    
+    //Before we get started, this test assumes certain things about Liberty:
+    //We assume it costs 150 culture.
+    //Liberty should be representative of most policies in the game.
+    //Some policies have special conditions under which they're blocked; I won't test those here.
+
+    game.opts.noConfirm = true;
+    
+    //Try buying an item, but we have 0 culture so it should fail:
+    controller.updateEnabled(model);
+    controller.buyItem(model, null, callbackFunction);
+    expect(model.metadata.researched).toBe(false);
+    expect(callbackResult).toHaveProperty("itemBought", false);
+    expect(callbackResult).toHaveProperty("reason", "cannot-afford");
+
+    //Give ourselves plenty of culture & try again; this time it should succeed:
+    game.resPool.get("culture").value = 500;
+    controller.updateEnabled(model);
+    controller.buyItem(model, null, callbackFunction);
+    expect(model.metadata.researched).toBe(true);
+    expect(callbackResult).toHaveProperty("itemBought", true);
+    expect(callbackResult).toHaveProperty("reason", "paid-for");
+    expect(game.resPool.get("culture").value).toBe(350);
+
+    //Try again; this time it should fail because already bought:
+    controller.updateEnabled(model);
+    controller.buyItem(model, null, callbackFunction);
+    expect(model.metadata.researched).toBe(true);
+    expect(callbackResult).toHaveProperty("itemBought", false);
+    expect(callbackResult).toHaveProperty("reason", "already-bought");
+    expect(game.resPool.get("culture").value).toBe(350);
+
+    //Now test that Tradition is correctly blocked.
+    model = controller.fetchModel({ id: "tradition" });
+    expect(model.metadata.blocked).toBe(true);
+    controller.updateEnabled(model);
+    controller.buyItem(model, null, callbackFunction);
+    expect(model.metadata.researched).toBe(false);
+    expect(callbackResult).toHaveProperty("itemBought", false);
+    expect(callbackResult).toHaveProperty("reason", "blocked");
+    expect(game.resPool.get("culture").value).toBe(350);
+});
+
+test("buyItem internals should work properly for Fix Cryochamber", () => {
+    const controller = new classes.ui.time.FixCryochamberBtnController(game);
+    let model = controller.fetchModel({});
+    let callbackResult = null;
+    const callbackFunction = function(result) { callbackResult = result; };
+    const cryochambers = game.time.getVSU("cryochambers");
+    const usedCryochambers = game.time.getVSU("usedCryochambers");
+
+    //Fixing a Cryochamber should fail when we don't have any Used Cryochambers.
+    controller.updateEnabled(model);
+    controller.updateVisible(model);
+    controller.buyItem(model, null, callbackFunction);
+    expect(callbackResult).toHaveProperty("itemBought", false);
+    expect(callbackResult).toHaveProperty("reason", "already-bought");
+    expect(cryochambers.val).toBe(0);
+    expect(usedCryochambers.val).toBe(0);
+
+    usedCryochambers.val = 5;
+    usedCryochambers.on = 5;
+
+    //Fixing a Cryochamber should fail when it's not unlocked yet.
+    controller.updateEnabled(model);
+    controller.updateVisible(model);
+    controller.buyItem(model, null, callbackFunction);
+    expect(callbackResult).toHaveProperty("itemBought", false);
+    expect(callbackResult).toHaveProperty("reason", "not-unlocked");
+    expect(cryochambers.val).toBe(0);
+    expect(usedCryochambers.val).toBe(5);
+
+    game.workshop.get("chronoforge").researched = true;
+
+    //Fixing a Cryochamber should fail when we can't afford it.
+    controller.updateEnabled(model);
+    controller.updateVisible(model);
+    controller.buyItem(model, null, callbackFunction);
+    expect(callbackResult).toHaveProperty("itemBought", false);
+    expect(callbackResult).toHaveProperty("reason", "cannot-afford");
+    expect(cryochambers.val).toBe(0);
+    expect(usedCryochambers.val).toBe(5);
+
+    for(const res of usedCryochambers.fixPrices) {
+        game.resPool.addResEvent(res.name, res.val + 1 /*Give us a little extra to check the price is correct*/);
+    }
+
+    //Fixing a Cryochamber should succeed this time.
+    controller.updateEnabled(model);
+    controller.updateVisible(model);
+    controller.buyItem(model, null, callbackFunction);
+    expect(callbackResult).toHaveProperty("itemBought", true);
+    expect(callbackResult).toHaveProperty("reason", "paid-for");
+    expect(cryochambers.val).toBe(1);
+    expect(usedCryochambers.val).toBe(4);
+
+    //Now check that it should have cost us the correct amount of resources:
+    for(const res of usedCryochambers.fixPrices) {
+        expect(game.resPool.get(res.name).value).toBe(1);
+    }
+});
+
+test("buyItem internals should work properly for crafting steel", () => {
+    const controller = new com.nuclearunicorn.game.ui.CraftButtonController(game);
+    const model = controller.fetchModel({ craft: "steel" });
+    let callbackResult = null;
+    const callbackFunction = function(result) { callbackResult = result; };
+    
+    //Before we get started, this test assumes certain things about crafting steel:
+    //We assume it costs 100 iron, 100 coal per craft.
+
+    //We should start out with no resources:
+    expect(game.resPool.get("steel").value).toBe(0);
+    expect(game.resPool.get("iron").value).toBe(0);
+    expect(game.resPool.get("coal").value).toBe(0);
+
+    //Crafting should fail when we can't afford it:
+    controller.buyItem(model, null, callbackFunction);
+    expect(callbackResult).toHaveProperty("itemBought", false);
+    expect(game.resPool.get("steel").value).toBe(0);
+    expect(callbackResult).toHaveProperty("itemBought", false);
+    expect(callbackResult).toHaveProperty("reason", "cannot-afford");
+
+    //Crafting should succeed when we can afford it:
+    game.resPool.addResEvent("iron", 199);
+    game.resPool.addResEvent("coal", 199);
+    controller.buyItem(model, null, callbackFunction);
+    expect(game.resPool.get("steel").value).toBe(1);
+    expect(callbackResult).toHaveProperty("itemBought", true);
+    expect(callbackResult).toHaveProperty("reason", "paid-for");
+
+    //Crafting should fail again because we consumed resources & don't have enough anymore:
+    controller.buyItem(model, null, callbackFunction);
+    expect(game.resPool.get("steel").value).toBe(1);
+    expect(game.resPool.get("iron").value).toBe(99);
+    expect(game.resPool.get("coal").value).toBe(99);
+    expect(callbackResult).toHaveProperty("itemBought", false);
+    expect(callbackResult).toHaveProperty("reason", "cannot-afford");
+});
+
+test("buyItem internals should work properly for shattering time crystals", () => {
+    const controller = new classes.ui.time.ShatterTCBtnController(game);
+    const model = controller.fetchModel({ prices: [{name: "timeCrystal", val: 1}] });
+    let callbackResult = null;
+    const callbackFunction = function(result) { callbackResult = result; };
+
+    //For shattering TCs, we'll watch what happens with the calendar year:
+    expect(game.calendar.year).toBe(0);
+
+    //Shattering should fail when we can't afford it:
+    controller.updateEnabled(model);
+    controller.buyItem(model, null, callbackFunction);
+    expect(game.calendar.year).toBe(0);
+    expect(callbackResult).toHaveProperty("itemBought", false);
+    expect(callbackResult).toHaveProperty("reason", "cannot-afford");
+
+    game.resPool.addResEvent("timeCrystal", 3);
+
+    //Shattering should succeed when we can afford it:
+    controller.updateEnabled(model);
+    controller.buyItem(model, null, callbackFunction);
+    expect(game.calendar.year).toBe(1);
+    expect(callbackResult).toHaveProperty("itemBought", true);
+    expect(callbackResult).toHaveProperty("reason", "paid-for");
+
+    //Shattering should have cost us the correct amount of time crystals.
+    expect(game.resPool.get("timeCrystal").value).toBe(2);
+});
+
+test("buyItem internals should work properly for items with no cost", () => {
+    let callbackResult = null;
+    const callbackFunction = function(result) { callbackResult = result; };
+    let handlerResult = null;
+    const handlerFunction = function(model) { handlerResult = model.name; };
+    let controller = new com.nuclearunicorn.game.ui.ButtonModernController(game);
+    let model = controller.fetchModel({ name: "A", prices: [], handler: handlerFunction });
+
+    //If we force-disable the model, we shouldn't be able to buy it:
+    model.enabled = false;
+    controller.buyItem(model, null, callbackFunction);
+    expect(callbackResult).toHaveProperty("itemBought", false);
+    expect(callbackResult).toHaveProperty("reason", "not-enabled");
+    expect(handlerResult).toBe(null); //Proof that the handler wasn't called
+
+    //Buying a free item should be free & call the handler:
+    model.enabled = true;
+    controller.buyItem(model, null, callbackFunction);
+    expect(callbackResult).toHaveProperty("itemBought", true);
+    expect(callbackResult).toHaveProperty("reason", "item-is-free");
+    expect(handlerResult).toBe("A");
+
+    controller = new classes.game.ui.GatherCatnipButtonController(game);
+    model = controller.fetchModel({}); //We don't really need any properties in the model for this one
+
+    //Gathering catnip should be free & always succeed:
+    expect(game.resPool.get("catnip").value).toBe(0);
+    controller.buyItem(model, null, callbackFunction);
+    expect(callbackResult).toHaveProperty("itemBought", true);
+    expect(callbackResult).toHaveProperty("reason", "item-is-free");
+    expect(game.resPool.get("catnip").value).toBe(1);
+
+    controller = new classes.ui.ChallengeBtnController(game);
+    model = controller.fetchModel({ id: "pacifism" });
+
+    //Toggle pending challenge should be free & always succeed:
+    expect(model.metadata.pending).toBe(false);
+    controller.buyItem(model, null, callbackFunction);
+    expect(callbackResult).toHaveProperty("itemBought", true);
+    expect(callbackResult).toHaveProperty("reason", "item-is-free");
+    expect(model.metadata.pending).toBe(true);
+    controller.buyItem(model, null, callbackFunction);
+    expect(callbackResult).toHaveProperty("itemBought", true);
+    expect(callbackResult).toHaveProperty("reason", "item-is-free");
+    expect(model.metadata.pending).toBe(false);
 });

--- a/test/setup.js
+++ b/test/setup.js
@@ -22,7 +22,7 @@ console.log("==== starting jest bootloader ====");
 */
 try {
     global.React = require("../lib/react.min.js");
-    require("../lib/jQuery");
+    global.$ = require("../lib/jQuery");
 
     //todo: make portable dojo for jest bootloader
     var createNamespace = require("./declare");
@@ -47,7 +47,11 @@ try {
                 predicate(array[i]);
             }
         },
-        clone: function(mixin){return Object.assign({}, mixin);},
+        clone: function(mixin){
+            if(mixin instanceof Array) { //Recursively deep-copying arrays?  What could go wrong?
+                return mixin.map(function(elem) { return global.dojo.clone(elem); });
+            }
+            return Object.assign({}, mixin);},
         hitch: function(ctx, method){ return method.bind(ctx, arguments);},
         connect: function(){},
         publish: function(){},
@@ -59,9 +63,10 @@ try {
         done: function(){return this},
         fail: function(){return this},
     }
-    global.$ = {
+    /*global.$ = {
         ajax: function(){ return xhrMock; }
-    }
+    }*/
+    global.$.ajax = function(){ return xhrMock; };
 
     global.LZString = require("../lib/lz-string.js");
     require("../lib/dropbox_v2.js");


### PR DESCRIPTION
I refactored how `buyItem` communicates to the outside program using the arguments passed to the `callback` function.  Now, in addition to telling us _whether_ an item was bought, we can also know _why_.

Along the way, I also fixed some queue issues that Ziggurat wanted me to address.

### Functional changes:
- If the queue can't buy an item because it's already bought to the limit (such as Resource Retrievals, Order of the Sun upgrades, or techs), or if the queue can't buy an item because its blocked (policies, including those with special conditions such as having a certain type of leader), or if the queue can't buy an item because the player canceled it when prompted with a confirmation pop-up, that item is removed from the queue.
- The game now shows a confirmation pop-up if the queue would build something that breaks Iron Will mode.
- A bunch of improvements to the "Fix Cryochambers" queue option.
### User interface changes:
- You don't have to click the on/off switch of the Tempus Fugit button to toggle acceleration; now clicking anywhere on the button will do.  I added this in because I wanted to, but I can revert this change if you don't like it.