### PR TITLE
Hydroponics display bug solution

### DIFF
--- a/core.js
+++ b/core.js
@@ -1560,7 +1560,7 @@ dojo.declare("com.nuclearunicorn.game.ui.BuildingBtnController", com.nuclearunic
 		var nextEffectValue = underlying.effects[effectName];
 		underlying.on--;
 		underlying.updateEffects(underlying, this.game);
-		//(cycleEffectsBasics is only relevant for space buildings & it will be applied at a later time so we skip it for now)
+		this.game.calendar.cycleEffectsBasics(underlying.effects, underlying.name);
 		return nextEffectValue;
 	},
 


### PR DESCRIPTION
The bug happen when the tooltip opened. The `getNextEffectValue` function is called when the tooltip calculates effects that do not use the "nonProportional" calculation (catnipRatio calculation is: undefined).
If the model has the `updateEffects` function, it will calculate the value of the effect as if you had one more of the building with the `cycleEffectsBasics`included, then does updateEffects again.
Because of this, the effects of the model only use the calculation of the `updateEffects` until the next tick occures (in the case of this bug: On Hydroponics the Cycle effect is displayed incorrectly when you mouse over the building).

Would it be alright to just do the  `cycleEffectsBasics` right there, or should I find a way to exclude the catnipRatio?