### PR TITLE
ci: Only deploy branches, not PRs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,4 +1,4 @@
-name: KG Deploy code
+name: KG Test/Deploy Code
 on:
   push:
     branches:
@@ -17,13 +17,16 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Yarn setup
-        uses: DerYeger/yarn-setup-action@master
+      - name: NodeJS setup
+        uses: actions/setup-node@v4
         with:
-          node-version: 16
+          node-version: 20
+
+      - name: Enable Corepack
+        run: corepack enable
 
       - name: Install dependencies
-        run: yarn
+        run: yarn install --frozen-lockfile
 
       - name: Lint
         run: yarn lint
@@ -36,7 +39,7 @@ jobs:
     if: github.event_name == 'push'
     needs: build
     steps:
-      - name: executing remote ssh commands using password
+      - name: Executing remote SSH commands using password
         uses: appleboy/ssh-action@v1.0.0
         with:
           username: ${{ secrets.KG_SSH_USER }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,7 +6,7 @@ on:
       - dev/alpha
       - dev/beta
   pull_request:
-    branches: 
+    branches:
       - master
       - dev/alpha
       - dev/beta
@@ -21,10 +21,10 @@ jobs:
         uses: DerYeger/yarn-setup-action@master
         with:
           node-version: 16
-      
+
       - name: Install dependencies
         run: yarn
-        
+
       - name: Lint
         run: yarn lint
 
@@ -33,6 +33,7 @@ jobs:
 
   deploy:
     runs-on: ubuntu-latest
+    if: github.event_name == 'push'
     needs: build
     steps:
       - name: executing remote ssh commands using password
@@ -42,5 +43,3 @@ jobs:
           host: ${{ secrets.KG_SSH_HOST }}
           key: ${{ secrets.KG_SSH_KEY }}
           script: /var/www/kittensgame.com/html/deploy.sh
-        
-        


### PR DESCRIPTION
1. Prevents PRs from running the deploy job
2. Uses `actions/setup-node` with latest NodeJS LTS version
3. Uses Corepack to enable NodeJS built-in package manager support
4. Requires lockfile to be up-to-date