### PR TITLE
feat: Create a log category for festivals

### DIFF
--- a/core.js
+++ b/core.js
@@ -419,7 +419,12 @@ dojo.declare("com.nuclearunicorn.game.log.Console", null, {
 				title: $I("console.filter.blackcoin"),
 				enabled: true,
 				unlocked: false
-			}
+			},
+			"festival": {
+				title: $I("console.filter.festival"),
+				enabled: true,
+				unlocked: false
+			},
 		}
 	},
 

--- a/game.js
+++ b/game.js
@@ -2103,29 +2103,7 @@ dojo.declare("com.nuclearunicorn.game.ui.GamePage", null, {
 	 * Display a message in the console. Returns a <span> node of a text container
 	 */
 	msg: function(message, type, tag, noBullet){
-
-		var filters = dojo.clone(this.console.filters);
-		if (tag && filters[tag]){
-			var filter = filters[tag];
-
-			if (!filter.enabled) {
-				return;
-			}
-		}
-
-		var hasCalendarTech = this.science.get("calendar").researched;
-
-		if (hasCalendarTech){
-			var currentDateMessage = $I("calendar.year.ext", [this.calendar.year.toLocaleString(), this.calendar.getCurSeasonTitle()]);
-			if (this.lastDateMessage !== currentDateMessage) {
-				this.console.msg(currentDateMessage, "date", null, false);
-				this.lastDateMessage = currentDateMessage;
-			}
-		}
-
-		var messageLine = this.console.msg(message, type, tag, noBullet);
-
-		return messageLine;
+		return this.console.msg(message, type, tag, noBullet);
 	},
 
 	clearLog: function(){

--- a/js/calendar.js
+++ b/js/calendar.js
@@ -439,7 +439,7 @@ dojo.declare("com.nuclearunicorn.game.Calendar", null, {
 			this.festivalDays--;
 			if(this.game.getEffect("festivalLuxuryConsumptionRatio")){
 				if(!this.game.resPool.get("furs").value || !this.game.resPool.get("ivory").value || !this.game.resPool.get("spice").value){
-					this.game.msg($I("village.festival.msg.deficitEnd"), "important");
+					this.game.msg($I("village.festival.msg.deficitEnd"), "important", "festival");
 					this.festivalDays = 0;
 				}
 			}

--- a/js/ui.js
+++ b/js/ui.js
@@ -933,7 +933,9 @@ dojo.declare("classes.ui.DesktopUI", classes.ui.UISystem, {
         dojo.empty(filtersDiv);
         var show = false;
 
-        for (var fId in console.filters){
+        var filtersSorted = Object.keys(console.filters).sort();
+        for (var filterIndex in filtersSorted) {
+            var fId = filtersSorted[filterIndex];
             if (console.filters[fId].unlocked) {
                 this._createFilter(console.filters[fId], fId, filtersDiv);
                 show = true;

--- a/js/village.js
+++ b/js/village.js
@@ -815,9 +815,9 @@ dojo.declare("classes.managers.VillageManager", com.nuclearunicorn.core.TabManag
 		}
 
 		if (festivalWasInProgress){
-			this.game.msg($I("village.festival.msg.ext"));
+			this.game.msg($I("village.festival.msg.ext"), null, "festival");
 		} else {
-			this.game.msg($I("village.festival.msg.start"));
+			this.game.msg($I("village.festival.msg.start"), null, "festival");
 		}
 		//TODO: some fun message like Molly Chalk is making a play 'blah blah'
 	},

--- a/res/i18n/en.json
+++ b/res/i18n/en.json
@@ -1765,6 +1765,7 @@
     "console.filter.faith": "Faith",
     "console.filter.elders": "Leviathans Arrival",
     "console.filter.blackcoin": "Blackcoin Transactions",
+    "console.filter.festival": "Festivals",
 
     "village.bonus.desc.chemist": "Chemical crafting bonus",
     "village.bonus.desc.engineer": "Crafting bonus",


### PR DESCRIPTION
1. Festivals can now be filtered from the log.
1. Sorts console filter UI elements alphabetically.
1. Removes redundant `msg` implementations. This also fixes disabled filters never appearing in the UI under certain conditions.

![image](https://github.com/nuclear-unicorn/kittensgame/assets/1658949/9b72a39b-e2ca-4bcf-b3db-1d39d489308c)
