### PR TITLE
Feature: Scientific Communism

### DIFF
--- a/js/buildings.js
+++ b/js/buildings.js
@@ -1413,6 +1413,12 @@ dojo.declare("classes.managers.BuildingsManager", com.nuclearunicorn.core.TabMan
 		calculateEffects: function(self, game){
 			if (self.val) {
 				game.time.queue.unlockQueueSource("upgrades");
+				if (self.val > 1) {
+					var thePolicy = game.science.getPolicy("scientificCommunism");
+					if (!thePolicy.researched) {
+						thePolicy.blocked = true;
+					}
+				}
 			}
 		},
 		flavor: $I("buildings.workshop.flavor")
@@ -1441,6 +1447,12 @@ dojo.declare("classes.managers.BuildingsManager", com.nuclearunicorn.core.TabMan
 			threshold: 20
 		},
 		calculateEffects: function(self, game){
+			if (self.val > 0) {
+				var thePolicy = game.science.getPolicy("scientificCommunism");
+				if (!thePolicy.researched) {
+					thePolicy.blocked = true;
+				}
+			}
 			var effects = {
 				"craftRatio": 0.05 * (1 + game.getEffect("environmentFactoryCraftBonus"))
 			};

--- a/js/science.js
+++ b/js/science.js
@@ -960,14 +960,46 @@ dojo.declare("classes.managers.ScienceManager", com.nuclearunicorn.core.TabManag
 	//----------------	meme --------------------
 	{
 		name: "socialism",
-        label: $I("policy.socialism.label"),
-        description: $I("policy.socialism.desc"),
+		label: $I("policy.socialism.label"),
+		description: $I("policy.socialism.desc"),
 		prices: [
 			{name : "culture", val: 7500}
 		],
 		unlocked: false,
 		blocked: false,
-        blocks:[]
+		blocks:[],
+		effects: {}, //Empty on purpose; this is a meme policy!
+		calculateEffects: function(self, game) {
+			var effects = {};
+			if (game.science.getPolicy("scientificCommunism").researched) {
+				var SCIENTIFIC_COMMUNISM_RATIO = 1.25;
+				for (var key in effects) {
+					effects[key] *= SCIENTIFIC_COMMUNISM_RATIO;
+				}
+			}
+			self.effects = effects;
+		},
+		unlocks: {
+			policies: ["scientificCommunism"]
+		}
+	},
+	{
+		name: "scientificCommunism",
+		label: $I("policy.scientificCommunism.label"),
+		description: $I("policy.scientificCommunism.desc"),
+		prices: [
+			{name : "culture", val: 8500}
+		],
+		unlocked: false,
+		evaluateLocks: function(game) {
+			//Secret policy that's only available if you never had more than 1 Workshop & never had any Factories.
+			return game.bld.get("workshop").val < 2 && game.bld.get("factory").val < 1 && game.science.getPolicy("socialism").researched;
+		},
+		blocked: false,
+		blocks:[],
+		upgrades: {
+			policies: ["socialism"]
+		},
 	},
 	//----------------	industrial age --------------------
 	{

--- a/res/i18n/en.json
+++ b/res/i18n/en.json
@@ -798,6 +798,8 @@
     "policy.rationing.desc": "Stoic philosophers encourage restraint and saving, making hunting more effective and reducing the effect of happiness on catnip consumption.",
     "policy.republic.label" : "Republic",
     "policy.republic.desc" : "Best for large societies. Highly promoted leaders will provide a small bonus to the production of all kittens.",
+    "policy.scientificCommunism.label" : "Scientific Communism",
+    "policy.scientificCommunism.desc" : "Increases all effects of Socialism by 25%",
     "policy.siphoning.label" : "Siphoning",
     "policy.siphoning.desc" : "Pacts consume alicorns and slow down corruption instead of consuming necrocorns. Lack of alicorns or corruption is compensated by consuming necrocorns.",
     "policy.socialism.label" : "Socialism",


### PR DESCRIPTION
Add Scientific Communism, a hidden policy available when the player purchases Socialism if they never had more than 1 Workshop & if they never built any Factories this run.
The effect of the policy is to boost Socialism's effects by 25%.