### PR TITLE
A few bugfixes & Easter eggs

### DIFF
--- a/js/resources.js
+++ b/js/resources.js
@@ -690,6 +690,14 @@ dojo.declare("classes.managers.ResourceManager", com.nuclearunicorn.core.TabMana
 				res.value = Math.min(res.value, res.maxValue);
 				continue;
 			}
+			if (res.name == "spice") { //This is a hack, will probably have to come up with a better system for this later
+				var now = new Date();
+				if (now.getMonth() == 9 && game.colorScheme == "spooky" && i18nLang.getLanguage() == "en") {
+					res.title = $I("resources.spice.title.october");
+				} else {
+					res.title = $I("resources.spice.title");
+				}
+			}
 
 			if (res.unlocked == false && res.value > 0){
 				res.unlocked = true;

--- a/js/space.js
+++ b/js/space.js
@@ -895,6 +895,14 @@ dojo.declare("classes.managers.SpaceManager", com.nuclearunicorn.core.TabManager
 						self.effects["hashRateLevel"] = 0;
 					}
 					self.effects["gflopsConsumption"] = 0.1;
+
+					//Hide all hash-related things from the tooltip if we don't have any hashes:
+					if (hr == 0) {
+						self.effects["hashrate"] = 0;
+						self.effects["nextHashLevelAt"] = 0;
+						self.effects["hrProgress"] = 0;
+						self.effects["hashRateLevel"] = 0;
+					}
 				}
 			}
 		]
@@ -1106,7 +1114,7 @@ dojo.declare("classes.managers.SpaceManager", com.nuclearunicorn.core.TabManager
 					}
 				}
 
-				if (bld.action && bld.val > 0){
+				if (bld.action && (bld.val > 0 || bld.name == "entangler")){ //Entanglers need to update hashrate level if we import a save that has 0 of them
 					var amt = bld.action(bld, this.game);
 					if (typeof(amt) != "undefined") {
 						bld.lackResConvert = amt != 1 && bld.on != 0;

--- a/js/ui.js
+++ b/js/ui.js
@@ -576,7 +576,7 @@ dojo.declare("classes.ui.DesktopUI", classes.ui.UISystem, {
         if (now.getDate() == 1 && now.getMonth() == 3) {
             $(".console-intro").css("font-size", "300%").addClass("blaze").text($I("console.intro.zebra"));
         } else {
-            $(".console-intro").text($I("console.intro"));
+            $(".console-intro").css("font-size", "100%").removeClass("blaze").text($I("console.intro"));
         }
 
         React.render($r(WLeftPanel, {

--- a/js/ui.js
+++ b/js/ui.js
@@ -1079,7 +1079,11 @@ dojo.declare("classes.ui.DesktopUI", classes.ui.UISystem, {
         }
 
         if (insertDateHeader) {
-            this.game.console.msg($I("calendar.year.ext", [messageLatest.year, messageLatest.seasonTitle]), "date", null, false);
+            if (!messageLatest.year || !messageLatest.seasonTitle) {
+                this.game.console.msg($I("ui.log.link"), "date", null, false);
+            } else {
+                this.game.console.msg($I("calendar.year.ext", [messageLatest.year, messageLatest.seasonTitle]), "date", null, false);
+            }
         }
 
         if (messageLatest.type === "date") {

--- a/js/village.js
+++ b/js/village.js
@@ -3372,7 +3372,8 @@ dojo.declare("com.nuclearunicorn.game.ui.tab.Village", com.nuclearunicorn.game.u
 			}),
 			controller: new classes.village.ui.VillageButtonController(this.game, {
 				updateVisible: function (model) {
-					model.visible = !this.game.isEldermass() && (this.game.resPool.get("elderBox").value > 0);
+					var elderBox = this.game.resPool.get("elderBox");
+					model.visible = !this.game.isEldermass() && (elderBox.value > 0) && !elderBox.isHidden;
 				}
 			})
 		}, this.game);
@@ -3415,6 +3416,7 @@ dojo.declare("com.nuclearunicorn.game.ui.tab.Village", com.nuclearunicorn.game.u
 
 		this.huntBtn && this.huntBtn.update();
 		this.festivalBtn && this.festivalBtn.update();
+		this.redeemGiftBtn && this.redeemGiftBtn.update();
 
 		this.mapPanel && this.mapPanel.update();
 		this.mapWgt && this.mapWgt.update();

--- a/res/i18n/en.json
+++ b/res/i18n/en.json
@@ -1168,6 +1168,7 @@
     "resources.slab.title": "slab",
     "resources.sorrow.title": "sorrow",
     "resources.spice.title": "spice",
+    "resources.spice.title.october": "pumpkin spice",
     "resources.starchart.title": "starchart",
     "resources.steel.title": "steel",
     "resources.tMythril.title": "T-Mythril",


### PR DESCRIPTION
- If the Calendar tech isn't researched, items that appear in the log won’t be listed as “Year null-null” anymore, they’ll just show under a generic header named “log.”
![image](https://github.com/nuclear-unicorn/kittensgame/assets/90073067/94aaf6d5-bc3e-41b6-9377-b4071bb2d621)
![image](https://github.com/nuclear-unicorn/kittensgame/assets/90073067/5e2267c6-16eb-4d6d-823b-246a2863cde1)
- Fixed a really obscure bug where importing a save with 0 entanglement stations could preserve an unnaturally high queue cap if the previous save had a bunch of hashrates.
- The “you are a kitten in a catnip forest” text will return to normal when April Fool’s Day ends.
- During the month of October, the resource “spice” is renamed to “pumpkin spice” if using the Spooky color theme.  (For now, it only happens if the game’s language is set to English.)
- The “unwrap present box” button will not be shown if present boxes are set to be hidden from the resource listing.