### PR TITLE
fix a dojo subscription leak from chiral

### DIFF
--- a/js/jsx/chiral.jsx.js
+++ b/js/jsx/chiral.jsx.js
@@ -160,7 +160,7 @@ WChiral = React.createClass({
         });
     },
 
-    componentWillUmount: function(){
+    componentWillUnmount: function(){
         dojo.unsubscribe(this.updateHandler);
     },
 


### PR DESCRIPTION
I noticed my tab running sluggishly [^1], dumped the heap, and quickly noticed about 64MB of retained closures in the ui/update topic listeners. I noticed they had the `setCommand` function and found this React component. It looks like there was a typo which prevents the unsubscription. I was able to confirm with the debugger that `componentDidMount` is called fairly frequently and that `componentWillUmount` does not get called.

The best I could do to verify this fix, since I don't have a user login server, was to change the condition to render the furthest ring tab and then check the listeners via `dojo._topics["ui/update"]._listeners`. Before the fix, this would grow by 1 each time you click in and out of the space tab. After apply the fix, it did not grow, though it appears `dojo.unsubscribe` simply deletes from the array, leaving it sparse. It appears to run just fine.

[^1]: I think KS is triggering the render, though I don't know how, so that's why the leak was so noticeable.