### PR TITLE
Hide wood separately in normal resources vs. crafted resources panel

### DIFF
--- a/game.js
+++ b/game.js
@@ -2275,7 +2275,7 @@ dojo.declare("com.nuclearunicorn.game.ui.GamePage", null, {
 		var saveData = {
 			saveVersion: this.saveVersion,
 			resources: this.resPool.filterMetadata(
-				this.resPool.resources, ["name", "value", "unlocked", "isHidden"]
+				this.resPool.resources, ["name", "value", "unlocked", "isHidden", "isHiddenFromCrafting"]
 			)
 		};
 

--- a/js/jsx/left.jsx.js
+++ b/js/jsx/left.jsx.js
@@ -413,7 +413,12 @@ WCraftRow = React.createClass({
     },
 
     getInitialState: function(){
-        return {visible: !this.props.resource.isHidden};
+        var res = this.props.resource;
+        if (res.name == "wood") {
+            return {visible: !res.isHiddenFromCrafting};
+        } else {
+            return {visible: !res.isHidden};
+        }
     },
 
     shouldComponentUpdate: function(nextProp, nextState){
@@ -503,7 +508,12 @@ WCraftRow = React.createClass({
 
     toggleView: function(){
         this.setState({visible: !this.state.visible});
-        this.props.resource.isHidden = this.state.visible; 
+        var res = this.props.resource;
+        if (res.name == "wood") {
+            res.isHiddenFromCrafting = this.state.visible;
+        } else {
+            res.isHidden = this.state.visible;
+        }
     },
 
     componentDidMount: function(){

--- a/js/resources.js
+++ b/js/resources.js
@@ -600,6 +600,10 @@ dojo.declare("classes.managers.ResourceManager", com.nuclearunicorn.core.TabMana
 
 			unlocked: false
 		};
+		if (name == "wood") {
+			//Wood is displayed as both a normal & a crafted resource.
+			res.isHiddenFromCrafting = false;
+		}
 		return res;
 	},
 
@@ -894,6 +898,10 @@ dojo.declare("classes.managers.ResourceManager", com.nuclearunicorn.core.TabMana
 			res.perTickCached = 0;
 			res.unlocked = false;
 			res.isHidden = false;
+
+			if (res.name == "wood") {
+				res.isHiddenFromCrafting = false;
+			}
 		}
 	},
 
@@ -1003,7 +1011,11 @@ dojo.declare("classes.managers.ResourceManager", com.nuclearunicorn.core.TabMana
 
 	setDisplayAll: function() {
 		for(var i = 0; i < this.resources.length; i++){
-			this.resources[i].isHidden = false;
+			var res = this.resources[i];
+			res.isHidden = false;
+			if (res.name == "wood") {
+				res.isHiddenFromCrafting = false;
+			}
 		}
 	},
 


### PR DESCRIPTION
It's a small UI improvement.  I don't know what else to say about it.
The wood resource now has 2 flags: `isHidden` for the normal resource pane & `isHiddenFromCrafting` for the craftable resource pane.  All other resources just use `isHidden` as before.