### PR TITLE
fix redshift applying calendar updates twice

### DIFF
--- a/js/time.js
+++ b/js/time.js
@@ -247,7 +247,7 @@ dojo.declare("classes.managers.TimeManager", com.nuclearunicorn.core.TabManager,
             var daysOffsetLeft = daysOffset;
             var redshiftQueueWorked = true;
             if (!result[1]){
-                numberEvents = this.applyRedshift(daysOffset);
+                numberEvents = this.applyRedshift(daysOffsetLeft, true);
                 daysOffsetLeft = 0;
             }
             while (daysOffsetLeft > 0){


### PR DESCRIPTION
The bug is that when applying redshift under certain conditions, `game.calendar.fastForward()` is called twice. This is triggered when:

1. The `QUEUE_REDSHIFT` flag is enabled (true by default)
2. The queue is empty

The short-circuiting path must call `this.applyRedshift(x, true)` to ignore the calendar, since `game.calendar.fastForward(x)` is called on the other side of the `while` loop. Without passing `true`, the calendar is advanced twice, meaning you get twice as many events, antimatter, beacon relics, void, and years as you would normally. Originally introduced in 66d451193.

You can reproduce this by pausing long enough for any of those values to tick (e.g., a few seconds for relics) and noting the difference in values compared to the number of days gained. With the patch, you no longer get twice as many.

I chose to rename `daysOffset` to `daysOffsetLeft` even though they're both the same value since it matches the other calls to `applyRedshift` in this branch and maybe somewhat indicates that we're only doing part of the work.

(I also submit this with a tinge of regret because I'm definitely abusing this to ramp void faster)