### PR TITLE
Import Tick Bugfixes

### DIFF
--- a/game.js
+++ b/game.js
@@ -3833,7 +3833,6 @@ dojo.declare("com.nuclearunicorn.game.ui.GamePage", null, {
 		//maybe it will be a good idea to move it elsewhere?
 
 		//for example, here kitten resources are calculated per effect, this logic could be unified
-
 		this.village.maxKittens = Math.floor(this.getEffect("maxKittens"));
 
 		this.village.update();
@@ -5092,7 +5091,7 @@ dojo.declare("com.nuclearunicorn.game.ui.GamePage", null, {
 				pacts: this.religion.pactsManager.pacts.map(getName),
 				challenges: this.challenges.challenges.map(getName)
 			};
-		this.upgrade({ buildings: ["warehouse"]});
+		this.upgrade({ buildings: ["warehouse"], spaceBuilding: ["hydroponics"]});
 		this.upgrade(metaKeys);
 		this.upgrade({policies: ["authocracy"]});
 	},
@@ -5222,8 +5221,13 @@ dojo.declare("com.nuclearunicorn.game.ui.GamePage", null, {
 					console.error("unable to get unlock by [id]", list[type][i], "[type]", type);
 					continue;
 				}
-				if (item.calculateEffects){
-					item.calculateEffects(item, this);
+				if (item.calculateEffects || item.updateEffects){
+					//Call calculateEffects or updateEffects, but don't call both.
+					if (item.calculateEffects) {
+						item.calculateEffects(item, this);
+					} else {
+						item.updateEffects(item, this);
+					}
 					if (type == "spaceBuilding") {
 						this.calendar.cycleEffectsBasics(item.effects, item.name);
 					}

--- a/game.js
+++ b/game.js
@@ -1781,7 +1781,6 @@ dojo.declare("com.nuclearunicorn.game.ui.GamePage", null, {
 	telemetry: null,
 	server: null,
 	math: null,
-	loadingSave: false, //while save is being imported we should ignore production from buildings for one tick; hack
 
 	//global cache
 	globalEffectsCached: {},
@@ -2684,9 +2683,7 @@ dojo.declare("com.nuclearunicorn.game.ui.GamePage", null, {
 				throw "Integrity check failure";
 			}
 
-			this.loadingSave = true;
 			this.load();
-			this.loadingSave = false;
 			this.msg($I("save.import.msg"));
 
 			this.render();

--- a/js/resources.js
+++ b/js/resources.js
@@ -689,9 +689,9 @@ dojo.declare("classes.managers.ResourceManager", com.nuclearunicorn.core.TabMana
 
 		for (var i in this.resources){
 			var res = this.resources[i];
+			this.updateMaxValue(res);
+
 			if (res.name == "sorrow"){
-				res.maxValue = 17 + (game.getEffect("blsLimit") || 0);
-				res.value = Math.min(res.value, res.maxValue);
 				continue;
 			}
 
@@ -705,21 +705,6 @@ dojo.declare("classes.managers.ResourceManager", com.nuclearunicorn.core.TabMana
 				}
 			}
 
-			var maxValue = game.getEffect(res.name + "Max") || 0;
-
-			maxValue = Math.min(this.addResMaxRatios(res, maxValue), Number.MAX_VALUE);
-			
-			var challengeEffect = this.game.getEffect(res.name + "MaxChallenge");
-			if(challengeEffect){
-				// Negative effect, no need to cap again to Number.MAX_VALUE
-				challengeEffect = this.game.getLimitedDR(this.addResMaxRatios(res, challengeEffect), maxValue - 1 - game.bld.effectsBase[res.name +'Max']||0);
-				maxValue += challengeEffect;
-			}
-
-			res.maxValue = Math.max(maxValue, 0);
-			if(game.loadingSave){ //hack to stop production before game.calculateAllEffects after manual import
-				continue;
-			}
 			var resPerTick = game.getResourcePerTick(res.name, false);
 			this.addResPerTick(res.name, resPerTick);
 
@@ -740,6 +725,40 @@ dojo.declare("classes.managers.ResourceManager", com.nuclearunicorn.core.TabMana
 			var energyLoss = calculateEnergyProduction(game, currentSeason) - calculateEnergyProduction(game, 3);
 			this.energyWinterProd -= solarFarm.get("on") * energyLoss * energyProdRatio;
 		}
+	},
+
+	/**
+	 * Updates the storage limit for a given resource.
+	 * @param res The resource object to be updated.
+	 */
+	updateMaxValue: function(res) {
+		var game = this.game;
+		if (res.name == "sorrow"){
+			res.maxValue = 17 + (game.getEffect("blsLimit") || 0);
+			res.value = Math.min(res.value, res.maxValue);
+			return;
+		}
+
+		var maxValue = game.getEffect(res.name + "Max") || 0;
+
+		maxValue = Math.min(this.addResMaxRatios(res, maxValue), Number.MAX_VALUE);
+		
+		var challengeEffect = this.game.getEffect(res.name + "MaxChallenge");
+		if(challengeEffect){
+			// Negative effect, no need to cap again to Number.MAX_VALUE
+			challengeEffect = this.game.getLimitedDR(this.addResMaxRatios(res, challengeEffect), maxValue - 1 - game.bld.effectsBase[res.name +'Max']||0);
+			maxValue += challengeEffect;
+		}
+
+		res.maxValue = Math.max(maxValue, 0);
+	},
+
+	/**
+	 * Updates the storage limit for a given resource.
+	 * @param resName The name of the resource to be updated.
+	 */
+	updateMaxValueByName: function(resName) {
+		this.updateMaxValue(this.get(resName));
 	},
 
 	//All energy production amounts are multiplied by this number.

--- a/js/space.js
+++ b/js/space.js
@@ -750,8 +750,11 @@ dojo.declare("classes.managers.SpaceManager", com.nuclearunicorn.core.TabManager
 				effects: {
 					"maxKittens": 1
 				},
-				action: function(self, game) {
+				updateEffects: function(self, game) {
 					self.effects["maxKittens"] = 1 + game.getEffect("terraformingMaxKittensRatio");
+				},
+				action: function(self, game) {
+					self.updateEffects(self, game);
 				},
 				unlocks: {
 					tabs: ["village"]

--- a/js/time.js
+++ b/js/time.js
@@ -108,7 +108,7 @@ dojo.declare("classes.managers.TimeManager", com.nuclearunicorn.core.TabManager,
 
 		// Update temporalFluxMax from values loaded
         this.game.updateCaches();
-        this.game.resPool.update();
+        this.game.resPool.updateMaxValueByName("temporalFlux");
 
 		var temporalAccelerator = this.getCFU("temporalAccelerator");
 		var energyRatio = 1 + (temporalAccelerator.val * temporalAccelerator.effects["timeRatio"]);


### PR DESCRIPTION
Fix 2 bugs that occur during the loading process.

### (1) Offline kitten arrival uses Hydroponics information from the previous game-state
Antipatience on Discord reported an issue where not enough kittens would arrive during redshift.
The issue was that during the loading process, Terraforming Stations didn't have max kittens updated properly, because their effects were updated only in the `action` function, which wouldn't have been called until after redshift calculations finished.
I fixed this by calling `updateEffects` whenever `calculateEffects` would be called, & by explicitly updating Hydroponics *before* calculating the effects of Terraforming Stations.  I also created an `updateEffects` function for Terraforming Stations.
I can confirm that this resolves the issue that Anti reported.
### (2) When the game-state is loaded, we get 1 tick of resource production using the previous game-state
This has been a known issue for a while.  The issue is that for offline temporal flux calculations, we need to calculate the storage capacity of temporal flux, & the only way to do this is to call `resPool.update()`, which also generates 1 tick of resource production for all resources.  So, I added a way to calculate a single resource's storage capacity without generating a tick of resource production.
Someone previously created a variable called `game.loadingSave` meant to address this problem, but in the comments they called their solution a "hack."  Additionally, their solution only worked for manually importing a save, not other methods of loading the game.  So, I tried to fix this problem in a more elegant way.  