### PR TITLE
Optimize bulk TC shattering

### DIFF
--- a/core.js
+++ b/core.js
@@ -44,6 +44,9 @@ dojo.declare("com.nuclearunicorn.core.TabManager", com.nuclearunicorn.core.Contr
 	 * >>
 	 * >>  constructor: function() { this.arrayField = []; }
 	 */
+
+	//effectsCachedExisting is a table of the names of every possible effect on each item in this game tab.
+	//If an effect somehow isn't in here, the TabManager doesn't know it exists.
 	effectsCachedExisting: null,
 	meta: null,
 	panelData: null,
@@ -125,16 +128,21 @@ dojo.declare("com.nuclearunicorn.core.TabManager", com.nuclearunicorn.core.Contr
 			effectsBase = this.game.resPool.addBarnWarehouseRatio(effectsBase);
 		}
 
+		//Initialize effectsCachedExisting to effectsBase
+		for (var name in this.effectsCachedExisting) {
+			this.effectsCachedExisting[name] = (effectsBase && effectsBase[name]) ? effectsBase[name] : 0;
+		}
+
 		for (var i = 0; i < this.meta.length; i++){
+			//This will collect all meta effects into effectsCachedExisting
+			//We're just using it as a temporary holding area
 			this.updateMetaEffectCached(this.meta[i]);
 		}
 
+		var globalEffects = this.game.globalEffectsCached;
 		for (var name in this.effectsCachedExisting) {
-			// Add effect from meta
-			var effect = 0;
-			for (var i = 0; i < this.meta.length; i++){
-				effect += this.getMetaEffect(name, this.meta[i]);
-			}
+			var effect = this.effectsCachedExisting[name];
+			this.effectsCachedExisting[name] = 0; //zero it out after using it
 
 			// Previously, catnip demand (or other buildings that both affect the same resource)
 			// could have theoretically had more than 100% reduction because they diminished separately,
@@ -143,20 +151,20 @@ dojo.declare("com.nuclearunicorn.core.TabManager", com.nuclearunicorn.core.Contr
 				effect = this.game.getLimitedDR(effect, 1);
 			}
 
-			// Add effect from effectsBase
-			if (effectsBase && effectsBase[name]) {
-				effect += effectsBase[name];
-			}
-
 			// Add effect in globalEffectsCached, in addition of other managers
-			this.game.globalEffectsCached[name] = typeof(this.game.globalEffectsCached[name]) == "number" ? this.game.globalEffectsCached[name] + effect : effect;
+			globalEffects[name] = typeof(globalEffects[name]) == "number" ? globalEffects[name] + effect : effect;
 		}
 	},
 
 	updateMetaEffectCached: function (metadata) {
+		//The object named "metadata" is a group of items from a panel in a tab in the game.
+		//For example, all Bonfire buildings, or all Order of the Sun upgrades, or all policies.
 		for (var i = 0; i < metadata.meta.length; i++){
 			var meta = metadata.meta[i];
 			meta.totalEffectsCached = {};
+			//The object named "meta" is an individual item in the game.
+
+			//Populate totalEffectsCached by looping through all types of effects we know about
 			for (var effectName in this.effectsCachedExisting){
 				var effect;
 				if (metadata.provider){
@@ -164,7 +172,12 @@ dojo.declare("com.nuclearunicorn.core.TabManager", com.nuclearunicorn.core.Contr
 				} else {
 					effect = meta.effects[effectName] || 0;
 				}
-				meta.totalEffectsCached[effectName] = effect;
+				if (effect != 0) { //ONLY create the entry if it matters
+					meta.totalEffectsCached[effectName] = effect;
+					//Hack to reduce number of nested loops:
+					// temporarily collect the values in effectsCachedExisting.
+					this.effectsCachedExisting[effectName] += effect;
+				}
 			}
 		}
 	},

--- a/js/time.js
+++ b/js/time.js
@@ -1,6 +1,6 @@
 dojo.declare("classes.managers.TimeManager", com.nuclearunicorn.core.TabManager, {
     game: null,
-    testShatter: 0, //0 is current function call, 1 is shatterInGroupCycles, 2 is shatterInCycles
+    testShatter: 0, //0 is current function call, 1 is shatterInGroupCycles, 2 is shatterInCycles (deprecated)
     /*
      * Amount of years skipped by CF time jumps
      */
@@ -698,6 +698,7 @@ dojo.declare("classes.managers.TimeManager", com.nuclearunicorn.core.TabManager,
     3)calculates Millenium production
     4)calculates flux
     likely to be deprecated after shatterInGroupCycles is finished
+       Note from another dev: it's deprecated already, so does that mean shatterInGroupCycles is finished now?
     */
     shatterInCycles: function(amt){
         amt = amt || 1;
@@ -942,7 +943,8 @@ dojo.declare("classes.managers.TimeManager", com.nuclearunicorn.core.TabManager,
                 this.shatter(shatters);
             }
             var oldShatterD2 = new Date();
-            console.log("oldShatterAverafe = " + (oldShatterD2.getTime() - oldShatterD1.getTime())/times);
+            //Average time in milliseconds to resolve 1 batch of *shatters* shatters, averaged across *times* trials
+            console.log("Old shatter average = " + (oldShatterD2.getTime() - oldShatterD1.getTime())/times + " ms");
         }
         if (!ignoreGroupCycles){
             var newShatterD1 = new Date();
@@ -950,15 +952,16 @@ dojo.declare("classes.managers.TimeManager", com.nuclearunicorn.core.TabManager,
                 this.shatterInGroupCycles(shatters);
             }
             var newShatterD2 = new Date();
-            console.log("Group shatter average = " + (newShatterD2.getTime() - newShatterD1.getTime())/times);
+            console.log("Group shatter average = " + (newShatterD2.getTime() - newShatterD1.getTime())/times + " ms");
         }
         if(!ignoreShatterInCycles){
+            //shatterInCycles is currently deprecated
             var new1ShatterD1 = new Date();
             for (var i = 0; i < times; i++){
                 this.shatterInCycles(shatters);
             }
             var new1ShatterD2 = new Date();
-            if(!ignoreShatterInCycles) {console.log("Cycle shatter average= " + (new1ShatterD2.getTime() - new1ShatterD1.getTime())/times);}
+            console.log("Cycle shatter average = " + (new1ShatterD2.getTime() - new1ShatterD1.getTime())/times + " ms");
         }
 
         if(!ignoreOldFunction && !ignoreGroupCycles){
@@ -966,6 +969,7 @@ dojo.declare("classes.managers.TimeManager", com.nuclearunicorn.core.TabManager,
         }
 
         if(!ignoreOldFunction && !ignoreShatterInCycles){
+            //shatterInCycles is currently deprecated
             console.log("new1Efficensy = " + (oldShatterD2.getTime() - oldShatterD1.getTime())/(new1ShatterD2.getTime() - new1ShatterD1.getTime()));
         }
     },


### PR DESCRIPTION
I spent some time optimizing the code.  From the data I collected on my machine, it shattering 50-100 TCs approximately 30% faster.  The benefit for shattering less than 50 TCs is smaller (closer to 15%), I didn't test batch sizes above 100 (I didn't have the patience for that), & I used small sample sizes (50 samples).  So there's a high degree of uncertainty in _how much_ faster the code actually is.  Nevertheless, the code is slightly faster.

Oh, it's probably also worth mentioning that all three shattering methods are improved by this.  Normal shattering, shattering with Temporal Accelerator automation on, & also shattering using the (now deprecated) "shatter in cycles" method.

Admittedly, these optimizations make the code harder to read, so I added a few comments to compensate.

`yarn test` looks good--all tests passing.