### PR TITLE
Unicorn tears science costs

### DIFF
--- a/game.js
+++ b/game.js
@@ -1746,6 +1746,9 @@ dojo.declare("com.nuclearunicorn.game.EffectsManager", null, {
 				title:  $I("effectsMgr.statics.pollutionRatio.title"),
 				type: "ratio"
 			},
+			"cathPollutionPerTearOvercapped": {
+				type: "hidden"
+			},
             //zebra workshop upgrades
             "zebraPreparations": {
                 title: $I("effectsMgr.statics.zebraPreparations.title"),

--- a/game.js
+++ b/game.js
@@ -1663,6 +1663,10 @@ dojo.declare("com.nuclearunicorn.game.EffectsManager", null, {
 				type: "ratio",
 				calculation: "nonProportional"
 			},
+			"scienceTearsPricesChallenge": {
+				title: $I("effectsMgr.statics.scienceTearsPricesChallenge.title"),
+				type: "ratio"
+			},
 			"workshopTearsPricesChallenge": {
 				title: $I("effectsMgr.statics.workshopTearsPricesChallenge.title"),
 				type: "ratio"

--- a/js/calendar.js
+++ b/js/calendar.js
@@ -646,6 +646,8 @@ dojo.declare("com.nuclearunicorn.game.Calendar", null, {
 				//Tears spill out of the container
 				var amtLost = tears.value - tears.maxValue;
 				this.game.resPool.addResEvent("tears", -amtLost);
+				//Tears evaporate into a smoky substance
+				this.game.bld.cathPollution += amtLost * this.game.getEffect("cathPollutionPerTearOvercapped");
 				this.game.msg($I("calendar.msg.tear.spilled", [this.game.getDisplayValueExt(amtLost)]));
 			}
 			var alicorns = this.game.resPool.get("alicorn");

--- a/js/challenges.js
+++ b/js/challenges.js
@@ -318,6 +318,7 @@ dojo.declare("classes.managers.ChallengesManager", com.nuclearunicorn.core.TabMa
 		effectDesc: $I("challendge.unicornTears.effect.desc"),
 		effects: {
 			"bonfireTearsPriceRatioChallenge": 0,
+			"scienceTearsPricesChallenge": 0,
 			"workshopTearsPricesChallenge": 0,
 			"cathPollutionPerTearOvercapped": 0, //Overcapped unicorn tears evaporate into a smoky substance
 			"unicornsMax": 0,
@@ -333,14 +334,18 @@ dojo.declare("classes.managers.ChallengesManager", com.nuclearunicorn.core.TabMa
 				//LDR limit is at a price ratio of ×2.5
 				self.effects["bonfireTearsPriceRatioChallenge"] =
 					game.getLimitedDR(1.2 + 0.03 * self.on, self.stackOptions["bonfireTearsPriceRatioChallenge"].LDRLimit);
+				//Increasing challenge: Multiplier to prices in the Science tab.
+				self.effects["scienceTearsPricesChallenge"] = 0.25;
 				//Increasing challenge: Multiplier to prices in the Workshop tab.
 				self.effects["workshopTearsPricesChallenge"] = 0.01;
 				self.effects["cathPollutionPerTearOvercapped"] = 3;
+				//Base resource storage:
 				self.effects["unicornsMax"] = 10;
 				self.effects["tearsMax"] = 1;
 				self.effects["alicornMax"] = 0.2;
 			} else {
 				self.effects["bonfireTearsPriceRatioChallenge"] = 0;
+				self.effects["scienceTearsPricesChallenge"] = 0;
 				self.effects["workshopTearsPricesChallenge"] = 0;
 				self.effects["cathPollutionPerTearOvercapped"] = 0;
 				self.effects["unicornsMax"] = 0;
@@ -350,6 +355,7 @@ dojo.declare("classes.managers.ChallengesManager", com.nuclearunicorn.core.TabMa
 		},
 		stackOptions: {
 			"bonfireTearsPriceRatioChallenge": { noStack: true, LDRLimit: 2.5 },
+			"scienceTearsPricesChallenge": { LDRLimit: 100 },
 			"workshopTearsPricesChallenge": { LDRLimit: 1 },
 			"cathPollutionPerTearOvercapped": { noStack: true },
 			"unicornsMax": { noStack: true },

--- a/js/challenges.js
+++ b/js/challenges.js
@@ -319,6 +319,7 @@ dojo.declare("classes.managers.ChallengesManager", com.nuclearunicorn.core.TabMa
 		effects: {
 			"bonfireTearsPriceRatioChallenge": 0,
 			"workshopTearsPricesChallenge": 0,
+			"cathPollutionPerTearOvercapped": 0, //Overcapped unicorn tears evaporate into a smoky substance
 			"unicornsMax": 0,
 			"tearsMax": 0,
 			"alicornMax": 0
@@ -334,12 +335,14 @@ dojo.declare("classes.managers.ChallengesManager", com.nuclearunicorn.core.TabMa
 					game.getLimitedDR(1.2 + 0.03 * self.on, self.stackOptions["bonfireTearsPriceRatioChallenge"].LDRLimit);
 				//Increasing challenge: Multiplier to prices in the Workshop tab.
 				self.effects["workshopTearsPricesChallenge"] = 0.01;
+				self.effects["cathPollutionPerTearOvercapped"] = 3;
 				self.effects["unicornsMax"] = 10;
 				self.effects["tearsMax"] = 1;
 				self.effects["alicornMax"] = 0.2;
 			} else {
 				self.effects["bonfireTearsPriceRatioChallenge"] = 0;
 				self.effects["workshopTearsPricesChallenge"] = 0;
+				self.effects["cathPollutionPerTearOvercapped"] = 0;
 				self.effects["unicornsMax"] = 0;
 				self.effects["tearsMax"] = 0;
 				self.effects["alicornMax"] = 0;
@@ -348,6 +351,7 @@ dojo.declare("classes.managers.ChallengesManager", com.nuclearunicorn.core.TabMa
 		stackOptions: {
 			"bonfireTearsPriceRatioChallenge": { noStack: true, LDRLimit: 2.5 },
 			"workshopTearsPricesChallenge": { LDRLimit: 1 },
+			"cathPollutionPerTearOvercapped": { noStack: true },
 			"unicornsMax": { noStack: true },
 			"tearsMax": { noStack: true },
 			"alicornMax": { noStack: true }

--- a/js/religion.js
+++ b/js/religion.js
@@ -1494,6 +1494,8 @@ dojo.declare("classes.ui.religion.TransformBtnController", com.nuclearunicorn.ga
 		if (gainRes.maxValue && amtWeCanAfford > 1) { //Perform this check only if we can afford 2 or more
 			var amtToReachCap = Math.ceil((gainRes.maxValue - gainRes.value) / this.controllerOpts.gainMultiplier.call(this));
 			amtWeCanAfford = Math.min(amtWeCanAfford, amtToReachCap);
+			//But don't go below 1 so we always give the player the option to sacrifice 1
+			amtWeCanAfford = Math.max(1, amtWeCanAfford);
 		}
 		return amtWeCanAfford;
 	},

--- a/js/religion.js
+++ b/js/religion.js
@@ -1540,6 +1540,10 @@ dojo.declare("classes.ui.religion.TransformBtnController", com.nuclearunicorn.ga
 		}
 
 		if (overcap > 0.001) { //Don't trigger from floating-point errors
+			if (this.controllerOpts.gainedResource == "tears") {
+				//Tears evaporate into a smoky substance
+				this.game.bld.cathPollution += overcap * this.game.getEffect("cathPollutionPerTearOvercapped");
+			}
 			//Optional parameter to display a message when we overcap:
 			if (typeof(this.controllerOpts.overcapMsgID) === "string") {
 				this.game.msg($I(this.controllerOpts.overcapMsgID, [this.game.getDisplayValueExt(overcap)]), "", this.controllerOpts.logfilterID, true /*noBullet*/);

--- a/js/religion.js
+++ b/js/religion.js
@@ -1536,6 +1536,11 @@ dojo.declare("classes.ui.religion.TransformBtnController", com.nuclearunicorn.ga
 
 		//Amount of the resource we failed to gain because we hit the cap:
 		var overcap = attemptedGainCount - actualGainCount;
+		if (actualGainCount == 0 && attemptedGainCount > 0 &&
+			this.game.resPool.get(this.controllerOpts.gainedResource).value / attemptedGainCount > 1e15) {
+			//We are in territory where overcap will be triggered due to floating-point precision limits.
+			overcap = 0;
+		}
 
 		if (this.controllerOpts.applyAtGain) {
 			this.controllerOpts.applyAtGain.call(this, priceCount);

--- a/js/science.js
+++ b/js/science.js
@@ -2192,6 +2192,30 @@ dojo.declare("classes.managers.ScienceManager", com.nuclearunicorn.core.TabManag
 			}
 		}
 
+		if (this.game.challenges.isActive("unicornTears")) {
+			var priceScaling = this.game.getEffect("scienceTearsPricesChallenge");
+			if (priceScaling > 0) {
+				//If the tech costs manuscripts, add unicorns to the price.
+				//If the tech costs compendia, add unicorn tears to the price.
+				//If the tech costs blueprints, add alicorns to the price.
+				for (var i = 0; i < prices.length; i += 1) {
+					switch(prices[i].name) {
+					case "manuscript":
+						prices_result = prices_result.concat([{name: "unicorns", val: prices[i].val * priceScaling}]);
+						break;
+					case "compedium":
+						prices_result = prices_result.concat([{name: "tears", val: prices[i].val * priceScaling}]);
+						break;
+					case "blueprint":
+						//Alicorn requirement is independent of the cost of the tech
+						//Minimum of 1, maximum of 10 with LDR.
+						prices_result = prices_result.concat([{name: "alicorn", val: Math.max(1, this.game.getLimitedDR(priceScaling, 10))}]);
+						break;
+					}
+				}
+			}
+		}
+
 		return prices_result;
 	},
     /*getEffect: function(effectName){
@@ -2533,17 +2557,9 @@ dojo.declare("com.nuclearunicorn.game.ui.TechButtonController", com.nuclearunico
     },
 
 	getPrices: function(model) {
-		var prices_result = this.game.village.getEffectLeader("scientist", this.inherited(arguments));
-
-		// this is to force Gold Ore pathway in BSK+IW and avoid soft locks
-		if(this.game.ironWill && this.game.challenges.isActive('blackSky')) {
-			if(model.metadata.name == 'construction') {
-				prices_result = prices_result.concat([{name: "gold", val: 5}]);
-			}
-		}
-
-		return prices_result;
-    },
+		//I want to avoid duplicate code if possible
+		return this.game.science.getPrices(model.metadata);
+	},
 
 	updateVisible: function(model){
 		var meta = model.metadata;

--- a/res/i18n/en.json
+++ b/res/i18n/en.json
@@ -542,6 +542,7 @@
     "effectsMgr.statics.sattelite-observatoryRatio.title": "Satellite - Observatory science bonus",
     "effectsMgr.statics.sattelite-starchartPerTickBaseSpace.title": "Satellite - Starchart production",
     "effectsMgr.statics.scienceMaxCompendia.title": "Compendia maximum science bonus",
+    "effectsMgr.statics.scienceTearsPricesChallenge.title": "Science tears prices",
     "effectsMgr.statics.sharedKnowledgeBonus.title" : "Science bonus from sharing knowledge",
     "effectsMgr.statics.shatterCostIncreaseChallenge.title": "Shatter TC cost increase",
     "effectsMgr.statics.shatterCostReduction.title": "Shatter TC cost reduction",


### PR DESCRIPTION
More functionality of the Unicorn Tears Challenge:
- Overcapping unicorn tears results in pollution (to discourage players from wasting precious unicorns when tears are at the cap).
- Increasing challenge: Technologies cost unicorns/tears/alicorns.
- Add some test cases & fix a bug with `_canAfford` calculations.