### PR TITLE
Fix 18 Bugs for Version 1.4.9.4

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -13,6 +13,7 @@ Minor:
 * Fix bugs related to Temporal Press
 * Fix bugs related to importing a save
 * Fix math errors related to Holy Genocide
+* Offline gflops should work correctly now.
 
 v 1.4.9.3
 Major:

--- a/game.js
+++ b/game.js
@@ -3812,14 +3812,6 @@ dojo.declare("com.nuclearunicorn.game.ui.GamePage", null, {
 		//hack end
 		this.time.update();
 
-		if (this.undoChange){
-			this.undoChange.ttl--;
-
-			if (this.undoChange.ttl <= 0){
-				this.undoChange = null;
-				this._publish("server/undoStateChanged");
-			}
-		}
         //--------------------
         //  Update UI state
         //--------------------
@@ -4569,6 +4561,14 @@ dojo.declare("com.nuclearunicorn.game.ui.GamePage", null, {
 		this.timer.updateScheduledEvents();
         var fpsElement;
 
+		if (this.undoChange){
+			//"Undo button" countdown should still tick while pawsed
+			this.undoChange.ttl--;
+			if (this.undoChange.ttl <= 0){
+				this.undoChange = null;
+				this._publish("server/undoStateChanged");
+			}
+		}
 		if (this.isPaused){
 			this.ui.update(); //Still update UI if the player gathers catnip while pawsed or something
 			return;

--- a/game.js
+++ b/game.js
@@ -911,7 +911,6 @@ dojo.declare("com.nuclearunicorn.game.EffectsManager", null, {
             },
 
 			"temporalParadoxChance": {
-				title: $I("effectsMgr.statics.temporalParadoxChance.title"),
 				type: "hidden"
 			},
 

--- a/game.js
+++ b/game.js
@@ -4379,7 +4379,10 @@ dojo.declare("com.nuclearunicorn.game.ui.GamePage", null, {
 
 		if(!value){ return "0"; }
 		if (value === Infinity) {
-			return "∞";
+			return prefix ? "+∞" : "∞";
+		}
+		if (value === -Infinity) {
+			return "-∞";
 		}
 
 		usePerTickHack &= this.opts.usePerSecondValues;

--- a/js/buildings.js
+++ b/js/buildings.js
@@ -2085,6 +2085,7 @@ dojo.declare("classes.managers.BuildingsManager", com.nuclearunicorn.core.TabMan
 				self.jammed = false;
 			}
 		},
+		jammed: false,
 		action: function(self, game){
 			if(self.val < 1 || self.jammed){
 				return;

--- a/js/buildings.js
+++ b/js/buildings.js
@@ -2708,12 +2708,22 @@ dojo.declare("classes.managers.BuildingsManager", com.nuclearunicorn.core.TabMan
 			this.cathPollution = Math.max(((this.cathPollution * pdr + uppt) * expon - uppt) / pdr, 0);
 		}
 	},
+	gflopsFastForward: function(ticks) {
+		var game = this.game;
+		var aiCore = this.get("aiCore");
+		var gflopsProduced = aiCore.effects["gflopsPerTickBase"] * aiCore.on * ticks;
+		game.resPool.get("gflops").value += gflopsProduced;
+	},
 	
 	fastforward: function(daysOffset) {
 		var game = this.game;
 
 		this.cacheCathPollutionPerTick();
 		this.cathPollutionFastForward(daysOffset * game.calendar.ticksPerDay);
+
+		if(game.opts.enableRedshiftGflops){
+			this.gflopsFastForward(daysOffset * game.calendar.ticksPerDay);
+		}
 
 		var steamworks = this.get("steamworks");
 		if (steamworks.on < 1 || !game.workshop.get("factoryAutomation").researched) {
@@ -2783,10 +2793,6 @@ dojo.declare("classes.managers.BuildingsManager", com.nuclearunicorn.core.TabMan
 		plateCrafter.craft();
 		slabCrafter.craft();
 		beamCrafter.craft();
-		if(game.opts.enableRedshiftGflops){
-			var aiCore = this.get("aiCore");
-			game.resPool.get("gflops").value += aiCore.effects["gflopsPerTickBase"] * aiCore.on * daysOffset * game.calendar.ticksPerDay;
-		}
 	},
 
 	undo: function(data){

--- a/js/calendar.js
+++ b/js/calendar.js
@@ -288,17 +288,11 @@ dojo.declare("com.nuclearunicorn.game.Calendar", null, {
 	},
 
 	observeTimeout: function(){
-
 		this.observeClear();
 
-		var autoChance = this.game.getEffect("starAutoSuccessChance");
-		if (this.game.prestige.getPerk("astromancy").researched){
-			autoChance *= 2;
-		}
-
+		var autoChance = this.getAstroEventAutoChance();
 		var rand = this.game.rand(100);
-		if (this.game.ironWill && rand <= 25
-		 || rand <= autoChance * 100) {
+		if (rand <= autoChance * 100) {
 			this.observeHandler();
 		}
 
@@ -359,6 +353,29 @@ dojo.declare("com.nuclearunicorn.game.Calendar", null, {
 		}
 
 		return effects;
+	},
+
+	//Returns a number in the interval [0,1]
+	getAstroEventAutoChance: function() {
+		var game = this.game;
+		if (game.workshop.get("seti").researched) {
+			return 1;
+		}
+		//Else, no SETI, so calculate based on Observatories:
+		var autoChance = game.getEffect("starAutoSuccessChance");
+		if (game.prestige.getPerk("astromancy").researched) {
+			autoChance *= 2;
+		}
+
+		if (game.ironWill) {
+			//Minimum 25% auto chance
+			autoChance = Math.max(0.25, autoChance);
+		} else {
+			//Don't go below 0
+			autoChance = Math.max(0, autoChance);
+		}
+		//Cap at 100% chance
+		return Math.min(autoChance, 1);
 	},
 
 	trueYear: function() {
@@ -685,19 +702,11 @@ dojo.declare("com.nuclearunicorn.game.Calendar", null, {
                 eventChance *= 2;
             }
 
-            var autoChance = this.game.getEffect("starAutoSuccessChance");
-            if (this.game.prestige.getPerk("astromancy").researched) {
-                autoChance *= 2;
-            }
-
-            if (this.game.workshop.get("seti").researched) {
-                autoChance = 1;
-            }
-            autoChance = Math.min(autoChance, 1);
+            var autoChance = this.getAstroEventAutoChance();
             //console.log("eventChance="+eventChance+", autoChance="+autoChance);
             numberEvents = Math.round(daysOffset * eventChance * autoChance);
             //console.log("number of startcharts="+numberEvents);
-            if (numberEvents) {
+            if (numberEvents && this.game.science.get("astronomy").researched) {
                 this.game.resPool.addResEvent("starchart", numberEvents);
             }
 

--- a/js/diplomacy.js
+++ b/js/diplomacy.js
@@ -549,13 +549,19 @@ dojo.declare("classes.managers.DiplomacyManager", null, {
 	},
 
 	getManpowerCost: function() {
-		 var manpowerCost = this.baseManpowerCost - this.game.getEffect("tradeCatpowerDiscount");
-		 return (manpowerCost < 0) ? 0 : manpowerCost;
+		var manpowerCost = this.baseManpowerCost - this.game.getEffect("tradeCatpowerDiscount");
+		if(this.game.challenges.isActive("postApocalypse")) {
+			manpowerCost *= 1 + this.game.bld.getPollutionLevel();
+		}
+		return (manpowerCost < 0) ? 0 : manpowerCost;
 	},
 
 	getGoldCost: function() {
-		 var goldCost = this.baseGoldCost - this.game.getEffect("tradeGoldDiscount");
-		 return (goldCost < 0) ? 0 : goldCost;
+		var goldCost = this.baseGoldCost - this.game.getEffect("tradeGoldDiscount");
+		if(this.game.challenges.isActive("postApocalypse")) {
+			goldCost *= 1 + this.game.bld.getPollutionLevel();
+		}
+		return (goldCost < 0) ? 0 : goldCost;
 	},
 
 	trade: function(race){
@@ -571,10 +577,6 @@ dojo.declare("classes.managers.DiplomacyManager", null, {
 		//-------------- pay prices ------------------
 		var manpowerCost = this.getManpowerCost();
 		var goldCost = this.getGoldCost();
-		if(this.game.challenges.isActive("postApocalypse")){
-			manpowerCost *= 1 + this.game.bld.getPollutionLevel();
-			goldCost *= 1 + this.game.bld.getPollutionLevel();
-		}
 		this.game.resPool.addResEvent("manpower", -manpowerCost * amt);
 		this.game.resPool.addResEvent("gold", -goldCost * amt);
 		this.game.resPool.addResEvent(race.buys[0].name, -race.buys[0].val * amt);
@@ -625,11 +627,6 @@ dojo.declare("classes.managers.DiplomacyManager", null, {
 	getMaxTradeAmt: function(race){
 		var manpowerCost = this.getManpowerCost();
 		var goldCost = this.getGoldCost();
-
-		if(this.game.challenges.isActive("postApocalypse")){
-			manpowerCost *= 1 + this.game.bld.getPollutionLevel();
-			goldCost *= 1 + this.game.bld.getPollutionLevel();
-		}
 
 		var amt = [
 			Math.floor(this.game.resPool.get("gold").value /
@@ -1445,10 +1442,6 @@ dojo.declare("com.nuclearunicorn.game.ui.tab.Diplomacy", com.nuclearunicorn.game
 			}
 
 			var tradePrices = [{ name: "manpower", val: this.game.diplomacy.getManpowerCost()}, { name: "gold", val: this.game.diplomacy.getGoldCost()}];
-			if(this.game.challenges.isActive("postApocalypse")){
-				tradePrices[0].val *= 1 + this.game.bld.getPollutionLevel();
-				tradePrices[1].val *= 1 + this.game.bld.getPollutionLevel();
-			}
 			tradePrices = tradePrices.concat(race.buys);
 
 			var tradeBtn = new com.nuclearunicorn.game.ui.TradeButton({

--- a/js/jsx/left.jsx.js
+++ b/js/jsx/left.jsx.js
@@ -779,12 +779,13 @@ WLeftPanel = React.createClass({
         var game = this.state.game,
             reqRes = game.getRequiredResources(game.selectedBuilding);
 
+        var huntCost = 100 - game.getEffect("huntCatpowerDiscount");
         var catpower = game.resPool.get("manpower");
-        var huntCount = Math.floor(catpower.value / 100);
+        var huntCount = Math.floor(catpower.value / huntCost);
 
         var canHunt = ((game.resPool.get("paragon").value > 0) || (game.science.get("archery").researched)) &&
             (!game.challenges.isActive("pacifism"));
-        var showFastHunt = (catpower.value >= 100);
+        var showFastHunt = (catpower.value >= huntCost);
 
         //---------- advisor ---------
         var showAdvisor = false;

--- a/js/jsx/left.jsx.js
+++ b/js/jsx/left.jsx.js
@@ -252,29 +252,20 @@ WResourceRow = React.createClass({
     componentDidMount: function(){
         var node = React.findDOMNode(this.refs.perTickNode);
         if (node){
-            this.tooltipNode = node;
+            this.refs.isTooltipAttached = true;
             game.attachResourceTooltip(node, this.props.resource);
         }
     },
 
     componentDidUpdate: function(prevProps, prevState){
-        if (!this.tooltipNode){
-            var node = React.findDOMNode(this.refs.perTickNode);
-            if (node){
-                this.tooltipNode = node;
-                game.attachResourceTooltip(node, this.props.resource);
-            }
+        var node = React.findDOMNode(this.refs.perTickNode);
+        if(this.refs.isTooltipAttached && !node) {
+            this.refs.isTooltipAttached = false;
         }
-    },
-
-    componentWillUnmount: function(){
-        if (!this.tooltipNode){
-            var node = React.findDOMNode(this.refs.perTickNode);
-            if (node){
-                this.tooltipNode = node;
-            }
+        if (node && !this.refs.isTooltipAttached) {
+            this.refs.isTooltipAttached = true;
+            game.attachResourceTooltip(node, this.props.resource);
         }
-        dojo.destroy(this.tooltipNode);
     }
 });
 
@@ -519,18 +510,19 @@ WCraftRow = React.createClass({
     componentDidMount: function(){
         var node = React.findDOMNode(this.refs.perTickNode);
         if (node){
-            this.tooltipNode = node;
+            this.refs.isTooltipAttached = true;
             game.attachResourceTooltip(node, this.props.resource);
         }
     },
 
     componentDidUpdate: function(prevProps, prevState){
-        if (!this.tooltipNode){
-            var node = React.findDOMNode(this.refs.perTickNode);
-            if (node){
-                this.tooltipNode = node;
-                game.attachResourceTooltip(node, this.props.resource);
-            }
+        var node = React.findDOMNode(this.refs.perTickNode);
+        if(this.refs.isTooltipAttached && !node) {
+            this.refs.isTooltipAttached = false;
+        }
+        if (node && !this.refs.isTooltipAttached) {
+            this.refs.isTooltipAttached = true;
+            game.attachResourceTooltip(node, this.props.resource);
         }
     }
 });

--- a/js/jsx/left.jsx.js
+++ b/js/jsx/left.jsx.js
@@ -319,17 +319,16 @@ WCraftShortcut = React.createClass({
 
         var node = React.findDOMNode(this.refs.linkBlock);
         if (node && node.firstChild){
-            this.tooltipNode = node;
-
             UIUtils.attachTooltip(game, node.firstChild, 0, 60, dojo.partial( function(recipe){
 				var tooltip = dojo.create("div", { className: "button_tooltip" }, null);
 				var prices = game.workshop.getCraftPrice(recipe);
 
 				var allCount = game.workshop.getCraftAllCount(recipe.name);
 				var ratioCount = Math.floor(allCount * ratio);
-				if (num < ratioCount){
-					num = ratioCount;
-				}
+
+				//num (craftFixed) specifies the minimum number of crafts
+				//But we want it to scale up with ratioCount as well
+				var craftRowAmt = Math.max(num, ratioCount);
 
 				for (var i = 0; i < prices.length; i++){
 					var price = prices[i];
@@ -343,7 +342,7 @@ WCraftShortcut = React.createClass({
 						}, priceItemNode );
 
 					dojo.create("span", {
-							innerHTML: game.getDisplayValueExt(price.val * num),
+							innerHTML: game.getDisplayValueExt(price.val * craftRowAmt),
 							style: {float: "right", paddingLeft: "6px" }
 						}, priceItemNode );
 				}

--- a/js/jsx/left.jsx.js
+++ b/js/jsx/left.jsx.js
@@ -47,13 +47,8 @@ WResourceRow = React.createClass({
         return {resource: null, isEditMode: false, isRequired: false, showHiddenResources: false};
     },
 
-    getInitialState: function(){
-        return {
-            visible: !this.props.resource.isHidden
-        };
-    },
-
     //this is a bit ugly, probably React.PureComponent + immutable would be a much better approach
+    //TODO: this function needs a proper rewrite.  I'm pretty sure it doesn't work at all as intended.
     shouldComponentUpdate: function(nextProp, nextState){
         var oldRes = this.oldRes || {},
             newRes = nextProp.resource;
@@ -66,7 +61,7 @@ WResourceRow = React.createClass({
             this.props.isRequired == nextProp.isRequired &&
             this.props.showHiddenResources == nextProp.showHiddenResources &&
             this.props.isTemporalParadox != nextProp.isTemporalParadox &&
-            this.state.visible == nextState.visible;
+            true /*this.state.visible == nextState.visible*/;
 
         if (isEqual){
             return false;
@@ -88,7 +83,7 @@ WResourceRow = React.createClass({
 
         var hasVisibility = (res.unlocked || (res.name == "kittens" && res.maxValue));
 
-        if (!hasVisibility || (!this.state.visible && !this.props.isEditMode)){
+        if (!hasVisibility || (!this.getIsVisible() && !this.props.isEditMode)){
             return null;
         }
 
@@ -214,7 +209,7 @@ WResourceRow = React.createClass({
                 $r("div", {className:"res-cell"},
                     $r("input", {
                         type:"checkbox", 
-                        checked: this.state.visible,
+                        checked: this.getIsVisible(),
 
                         onClick: this.toggleView,
                         style:{display:"inline-block"},
@@ -245,8 +240,11 @@ WResourceRow = React.createClass({
     },
 
     toggleView: function(){
-        this.setState({visible: !this.state.visible});
-        this.props.resource.isHidden = this.state.visible; 
+        this.props.resource.isHidden = !this.props.resource.isHidden;
+    },
+
+    getIsVisible: function() {
+        return !this.props.resource.isHidden;
     },
 
     componentDidMount: function(){
@@ -403,15 +401,6 @@ WCraftRow = React.createClass({
         return {resource: null, isEditMode: false};
     },
 
-    getInitialState: function(){
-        var res = this.props.resource;
-        if (res.name == "wood") {
-            return {visible: !res.isHiddenFromCrafting};
-        } else {
-            return {visible: !res.isHidden};
-        }
-    },
-
     shouldComponentUpdate: function(nextProp, nextState){
         var newRes = nextProp.resource;
 
@@ -435,7 +424,7 @@ WCraftRow = React.createClass({
 
         var recipe = game.workshop.getCraft(res.name);
         var hasVisibility = (res.unlocked && recipe.unlocked /*&& this.workshop.on > 0*/);
-        if (!hasVisibility || (!this.state.visible && !this.props.isEditMode)){
+        if (!hasVisibility || (!this.getIsVisible() && !this.props.isEditMode)){
             return null;
         }
 
@@ -471,7 +460,7 @@ WCraftRow = React.createClass({
                 $r("div", {className:"res-cell"},
                     $r("input", {
                         type:"checkbox", 
-                        checked: this.state.visible,
+                        checked: this.getIsVisible(),
                         onClick: this.toggleView,
                         style:{display:"inline-block"},
                     })
@@ -498,13 +487,21 @@ WCraftRow = React.createClass({
     },
 
     toggleView: function(){
-        this.setState({visible: !this.state.visible});
         var res = this.props.resource;
         if (res.name == "wood") {
-            res.isHiddenFromCrafting = this.state.visible;
+            res.isHiddenFromCrafting = !res.isHiddenFromCrafting;
         } else {
-            res.isHidden = this.state.visible;
+            res.isHidden = !res.isHidden;
         }
+    },
+
+    getIsVisible: function() {
+        var res = this.props.resource;
+        if (res.name == "wood") {
+            //(Wood is special because it appears twice, separately)
+            return !res.isHiddenFromCrafting;
+        }
+        return !res.isHidden;
     },
 
     componentDidMount: function(){

--- a/js/space.js
+++ b/js/space.js
@@ -277,14 +277,15 @@ dojo.declare("classes.managers.SpaceManager", com.nuclearunicorn.core.TabManager
 					self.effects["energyConsumption"] = 1;
 				}
 
+				game.upgrade(self.upgrades); //this way observatories won't have to use action
+
 				if (game.challenges.isActive("blackSky")) {
 					self.effects['starchartPerTickBaseSpace'] *= 1 / (1 + game.getEffect('bskSattelitePenalty'));
 				}
-
-				game.upgrade(self.upgrades); //this way observatories won't have to use action
 			},
 			upgrades: {
-				buildings: ["observatory"]
+				buildings: ["observatory"],
+				challenges: ["blackSky"]
 			},
 			unlockScheme: {
 				name: "space",

--- a/js/ui.js
+++ b/js/ui.js
@@ -769,6 +769,9 @@ dojo.declare("classes.ui.DesktopUI", classes.ui.UISystem, {
             $("#tooltip").detach().appendTo("#game").removeClass("tooltip-in-right-column");
         }
 
+        //It would be nice to have a system for options that would take care of this automatically,
+        //  instead of a dev having to add a new line of code here for every new option that gets added.
+
         $("#workersToggle")[0].checked = game.useWorkers;
         $("#forceHighPrecision")[0].checked = game.opts.forceHighPrecision;
         $("#usePerSecondValues")[0].checked = game.opts.usePerSecondValues;
@@ -781,6 +784,7 @@ dojo.declare("classes.ui.DesktopUI", classes.ui.UISystem, {
         $("#hideBGImage")[0].checked = game.opts.hideBGImage;
         $("#tooltipsInRightColumn")[0].checked = game.opts.tooltipsInRightColumn;
         $("#enableRedshift")[0].checked = game.opts.enableRedshift;
+        $("#enableRedshiftGflops")[0].checked = game.opts.enableRedshiftGflops;
         $("#batchSize")[0].value = game.opts.batchSize;
         $("#forceLZ")[0].checked = game.opts.forceLZ;
         $("#compressSaveFile")[0].checked = game.opts.compressSaveFile;

--- a/js/village.js
+++ b/js/village.js
@@ -1854,10 +1854,15 @@ dojo.declare("classes.ui.village.BiomeBtnController", com.nuclearunicorn.game.ui
 	},
 
 	clickHandler: function(model, event){
+		var map = this.game.village.map;
+		if (map.energy <= 0 || map.hp <= 0)
+		{
+			//Not enough resources to explore
+			return;
+		}
 		var biome = model.biome;
 		console.log("CURRENT BIOME:", biome);
 
-		var map = this.game.village.map;
 		map.currentBiome = biome.name;
 	},
 
@@ -1893,6 +1898,17 @@ dojo.declare("classes.ui.village.BiomeBtnController", com.nuclearunicorn.game.ui
 
 	updateVisible: function(model){
 		model.visible = this.biome.unlocked;
+	},
+	updateEnabled: function(model) {
+		var map = this.game.village.map;
+		if (map.energy <= 0 || map.hp <= 0)
+		{
+			//Not enough resources to explore
+			model.enabled = false;
+			return;
+		}
+
+		this.inherited(arguments);
 	}
 });
 

--- a/js/village.js
+++ b/js/village.js
@@ -1961,8 +1961,9 @@ dojo.declare("classes.ui.village.BiomeBtn", com.nuclearunicorn.game.ui.ButtonMod
 						innerHTML: fauna.title /*+ " | a:" + fauna.atk + ", d:" + fauna.def*/,
 						style: { float: "left" }
 					}, faunaNode );
+					var game = model.options.controller.game;
 					var statsSpan = dojo.create("span", {
-						innerHTML: this.game.getDisplayValueExt(fauna.hp) + "hp",
+						innerHTML: game.getDisplayValueExt(fauna.hp) + "hp",
 						style: { float: "right" }
 					}, faunaNode );
 

--- a/js/village.js
+++ b/js/village.js
@@ -2528,6 +2528,7 @@ dojo.declare("classes.village.KittenSim", null, {
 					jobKittens.splice(i, 1); //Delete element from middle of array
 					this.game.village.unassignJob(kitten);
 					amt -= 1; //Decrement counter of kittens to unassign.
+					i -= 1; //Shift index so we don't accidentally skip any array elements.
 				}
 			}
 		}

--- a/js/workshop.js
+++ b/js/workshop.js
@@ -2889,7 +2889,7 @@ dojo.declare("com.nuclearunicorn.game.ui.CraftButtonController", com.nuclearunic
 				model.unassignCraftLinks = [
 				  {
 						id: "unassign",
-						title: "[&ndash;]",
+						title: "[-]",
 						handler: function(){
 							self.unassignCraftJob(model, 1);
 						},

--- a/res/i18n/en.json
+++ b/res/i18n/en.json
@@ -1022,7 +1022,7 @@
     "religion.pact.pactOfFanaticism.desc": "Great devotion requires great sacrifise!",
     "religion.pact.pactOfPurity.label": "Pact of Purity",
     "religion.pact.pactOfPurity.desc": "Purify the mortal plane, gaining insight into secrets of the universe and clearing reality from strains of darkness.",
-    "religion.pact.payDebt.label": "Pay the dept",
+    "religion.pact.payDebt.label": "Pay the debt",
     "religion.pact.payDebt.desc": "Get rid of Necrocorn Deficit by giving up enough necrocorns",
 	"religion.pact.fractured.label": "Fractured",
 	"religion.pact.fractured.desc": "You have broken the deal... now you will pay",


### PR DESCRIPTION
1. Fix biome tooltips not displaying properly if there were any fauna.
2. The workshop buttons to unassign engineers from crafting now show [-] instead of [&ndash;].
3. Fix a bug where the value of N in the quick link “send hunters (N times)” didn’t account for reduced cost due to Dragon Dynamicists policy.
4. Fix that it was possible to start exploring a biome while explorers’ HP was negative.
5. The timer for the undo button no longer stops counting when the game is pawsed.
6. Fix that the links to trade in bulk (20%, 50%) would be visible in Post Apocalypse in certain circumstances when they shouldn’t have been.
7. The getDisplayValueExt(…) function properly handles negative Infinity, & positive Infinity will have a plus sign in front if the relevant flag is set.  This fixes an obscure bug where the game would not be able to properly render the decreased storage effect of the Atheism Challenge if you had infinite paragon.
8. Fix that the “offline gflops progression” setting wouldn’t appear to be checked in the options menu even if it was set to true.
9. Fix that offline gflops production would be skipped if Steamworks were turned off, or if automation was disabled, or if resource caps weren’t initialized yet, or if nothing would be crafted, or if Workshop Automation wasn’t researched yet.
10. Fixed a bug where the production tooltip breakdowns would stop showing up if the resource in question was hidden earlier in the same session.
11. When you import a save, it now instantly applies the new settings for which resources (in the left pane) to be hidden.
12. Fixed a bug where the tooltips for crafting columns on the resource pane wouldn’t update correctly since the number of possible crafts would increase but not decrease properly.
13. Fix console error with missing i18n string for “temporal paradox chance” hidden effect.
14. Fix console warning with missing “jammed” property of Zebra Outposts.
15. In the Pacts UI, “pay the dept” has been corrected to “pay the debt.”
16. Fix the bug where in the Black Sky Challenge, Satellites wouldn’t respect the penalty during redshift (due to the order in which effects were calculated).
17. Fix the bug where the minimum 25% auto-success chance for rare astronomical events (one of the buffs exclusive to Iron Will mode) didn’t work in redshift.
18. When you unassign kittens from the engineer job, it’s supposed to prioritize engineers who are currently crafting nothing.  There was a bug where this didn’t always work.  That bug has now been fixed.

Of the bugs listed above, fewer than 20 are my fault.
