### PR TITLE
Balancing proposal

### DIFF
--- a/game.js
+++ b/game.js
@@ -1570,6 +1570,10 @@ dojo.declare("com.nuclearunicorn.game.EffectsManager", null, {
 				title: $I("effectsMgr.statics.unobtainiumPolicyRatio.title"),
 				type: "ratio"
             },
+			"antimatterPolicyRatio":{
+				title: $I("effectsMgr.statics.antimatterPolicyRatio.title"),
+				type: "ratio"
+			},
             "sciencePolicyRatio":{
 				title: $I("effectsMgr.statics.sciencePolicyRatio.title"),
 				type: "ratio"
@@ -3749,6 +3753,11 @@ dojo.declare("com.nuclearunicorn.game.ui.GamePage", null, {
 				value: -this.getEffect(res.name + "Production")
 			});
 		}
+		stack.push({
+			name: $I("res.stack.policy"),
+			type: "ratio",
+			value: this.getEffect(res.name + "PolicyRatio")
+		});
 		return stack;
 	},
 	getCMBRBonus: function() {
@@ -3931,14 +3940,11 @@ dojo.declare("com.nuclearunicorn.game.ui.GamePage", null, {
 	},
 	getResourceOnYearProduction: function(resName){
 		if (resName == "antimatter"){
-			if(this.resPool.energyProd >= this.resPool.energyCons){
-				return this.getEffect("antimatterProduction");
-			}
-			else{
+			if(this.resPool.energyProd < this.resPool.energyCons){
 				return 0;
 			}
 		}
-		return this.getEffect(resName + "Production"); //this might need to be changed!
+		return this.getEffect(resName + "Production") * (1 + this.getEffect(resName + "PolicyRatio"));
 	},
 	getResourcePerTickConvertion: function(resName) {
 		return this.fixFloatPointNumber(this.getEffect(resName + "PerTickCon"));
@@ -4118,6 +4124,7 @@ dojo.declare("com.nuclearunicorn.game.ui.GamePage", null, {
 
 			if (!stackElem.value || (stackElem.type != "fixed" && stackElem.type != "perDay" &&
 			stackElem.type != "perYear" && !hasFixed)) {
+				//If hasFixed is false, no need to display ratio effects
 				continue;
 			}
 
@@ -4130,7 +4137,8 @@ dojo.declare("com.nuclearunicorn.game.ui.GamePage", null, {
 			}
 
 			resString += this.getStackElemString(stackElem, res);
-			if (stackElem.type == "fixed" || stackElem.type == "perDay") {
+			if (stackElem.type == "fixed" || stackElem.type == "perDay" || stackElem.type == "perYear") {
+				//Below this point, display all ratio effects
 				hasFixed = true;
 			}
 		}

--- a/game.js
+++ b/game.js
@@ -1921,7 +1921,7 @@ dojo.declare("com.nuclearunicorn.game.ui.GamePage", null, {
 			mobile: false
 		},
 		SPACE_EXPL: {
-			beta: true,
+			beta: false,
 			main: false,
 			mobile: false
 		},

--- a/game.js
+++ b/game.js
@@ -3773,7 +3773,7 @@ dojo.declare("com.nuclearunicorn.game.ui.GamePage", null, {
 			var policyRefineRatio = this.getEffect("refinePolicyRatio");
 			var refineRatio =  (policyRefineRatio) + (1 + policyRefineRatio) * this.getEffect("refineRatio");
 			return this.ironWill
-				? ((1 + refineRatio) * (1 + this.getEffect("woodRatio"))) - 1
+				? ((1 + refineRatio) * (1 + this.getEffect("woodRatio") + this.getEffect("woodPolicyRatio") / 3)) - 1
 				: refineRatio;
 		}
 

--- a/js/buildings.js
+++ b/js/buildings.js
@@ -1650,12 +1650,13 @@ dojo.declare("classes.managers.BuildingsManager", com.nuclearunicorn.core.TabMan
 
 			var manpower = game.resPool.get("manpower");
 			var mpratio = (manpower.maxValue * 0.007) / 100;
+			var autocracyBonus = game.getEffect("rankLeaderBonusConversion") * ((game.village.leader) ? game.village.leader.rank : 0);
 
 			//hidden 1% boost to mints from village level
 			mpratio *= (1 + game.village.map.villageLevel * 0.005);
 			mpratio *= (1 + game.getEffect("mintRatio"));
-			self.effects["fursPerTickProd"]  = mpratio * 1.25;	//2
-			self.effects["ivoryPerTickProd"] = mpratio * 0.3 * (1 + game.getEffect("mintIvoryRatio"));	//1.5
+			self.effects["fursPerTickProd"]  = mpratio * (1 + autocracyBonus / 2) * 1.25;	//2
+			self.effects["ivoryPerTickProd"] = mpratio * (1 + autocracyBonus / 6) * 0.3 * (1 + game.getEffect("mintIvoryRatio"));	//1.5
 
 			var amt = game.resPool.getAmtDependsOnStock(
 				[{res: "gold", amt: -self.effects["goldPerTickCon"]},

--- a/js/calendar.js
+++ b/js/calendar.js
@@ -804,7 +804,7 @@ dojo.declare("com.nuclearunicorn.game.Calendar", null, {
 		//antimatter
 		var resPool = this.game.resPool;
 		if (resPool.energyProd >= resPool.energyCons) {
-			resPool.addResEvent("antimatter", this.game.getEffect("antimatterProduction") * yearsOffset);
+			resPool.addResEvent("antimatter", this.game.getResourceOnYearProduction("antimatter") * yearsOffset);
 		}
 
 		var beacons = this.game.space.getBuilding("spaceBeacon");
@@ -965,10 +965,10 @@ if (++this.cycleYear >= this.yearsPerCycle) {
 
 		var resPool = this.game.resPool;
 		if (resPool.energyProd >= resPool.energyCons) {
-			resPool.addResEvent("antimatter", this.game.getEffect("antimatterProduction") * years);
+			resPool.addResEvent("antimatter", this.game.getResourceOnYearProduction("antimatter") * years);
 		}
 
-		resPool.addResEvent("temporalFlux", this.game.getEffect("temporalFluxProduction") * years);
+		resPool.addResEvent("temporalFlux", this.game.getResourceOnYearProduction("temporalFlux") * years);
 
 		var aiLevel = this.game.bld.get("aiCore").effects["aiLevel"];
 		if ((aiLevel > 14) && (this.game.science.getPolicy("transkittenism").researched != true)){
@@ -1043,10 +1043,10 @@ if (++this.cycleYear >= this.yearsPerCycle) {
 
 		var resPool = this.game.resPool;
 		if (resPool.energyProd >= resPool.energyCons) {
-			resPool.addResEvent("antimatter", this.game.getEffect("antimatterProduction"));
+			resPool.addResEvent("antimatter", this.game.getResourceOnYearProduction("antimatter"));
 		}
 
-		resPool.addResEvent("temporalFlux", this.game.getEffect("temporalFluxProduction"));
+		resPool.addResEvent("temporalFlux", this.game.getResourceOnYearProduction("temporalFlux"));
 
 		var aiLevel = this.game.bld.get("aiCore").effects["aiLevel"];
 		if ((aiLevel > 14) && (this.game.science.getPolicy("transkittenism").researched != true)){

--- a/js/calendar.js
+++ b/js/calendar.js
@@ -528,6 +528,7 @@ dojo.declare("com.nuclearunicorn.game.Calendar", null, {
 
 			if (this.game.ironWill){
 				mineralsAmt += mineralsAmt * 0.1;	//+10% of minerals for iron will
+				mineralsAmt *= 1 + this.game.getEffect("mineralsPolicyRatio") / 3;
 			}
 			mineralsAmt *= 1 + minerologyBonus;
 			var mineralsGain = this.game.resPool.addResEvent("minerals", mineralsAmt);

--- a/js/challenges.js
+++ b/js/challenges.js
@@ -566,12 +566,6 @@ dojo.declare("classes.managers.ChallengesManager", com.nuclearunicorn.core.TabMa
 	},
 
 	update: function(){
-		// energy
-		if (this.getChallenge("energy").unlocked == false) {
-			if (this.game.resPool.energyProd != 0 || this.game.resPool.energyCons != 0) {
-				this.getChallenge("energy").unlocked = true;
-			}
-		} 
 		//Disable challenge if the feature flag for it is disabled
 		if (!this.game.getFeatureFlag("UNICORN_TEARS_CHALLENGE")) {
 			var chall = this.getChallenge("unicornTears");
@@ -699,16 +693,6 @@ dojo.declare("classes.managers.ChallengesManager", com.nuclearunicorn.core.TabMa
 		}, function() {
 		});
 	},
-
-	//TODO: rewrite using the general getEffect logic
-
-	/*getChallengeEffect: function(name, type) {
-		var challenge = this.getChallenge(name);
-		if (name == "energy") {
-			return 2 + 0.1 * challenge.val;
-		}
-	},*/
-
 });
 
 dojo.declare("classes.reserveMan", null,{

--- a/js/diplomacy.js
+++ b/js/diplomacy.js
@@ -1018,6 +1018,20 @@ dojo.declare("classes.diplomacy.ui.EmbassyButtonController", com.nuclearunicorn.
 		return result;
 	},
 
+	getEffects: function(model) {
+		var race = model.options.race;
+		var nagaArchitects = this.game.science.getPolicy("nagaRelationsArchitects");
+		if (race.name == "nagas" && nagaArchitects.researched) {
+			return nagaArchitects.effects;
+		}
+		//Else,there are no effects associated with this embassy.
+		return undefined;
+	},
+	getTotalEffects: function(model) {
+		//Force this to return a falsy value so the game uses normal getEffects() instead
+		return undefined;
+	},
+
 	getMetadata: function(model) {
 		if (!model.metaCached) {
 			var race = model.options.race;
@@ -1102,8 +1116,8 @@ var EmbassyButtonHelper = {
 
 			//You must have done a bunch of trading already (with any race) before embassies show you this advanced info:
 			var TOTAL_TRADES_TO_SEE_CHANCES = 50;
-			//Ability to render effects is replaced with this because I want to try something a little different for embassies.
 			if (controller.game.stats.getStatCurrent("totalTrades").val >= TOTAL_TRADES_TO_SEE_CHANCES) {
+				ButtonModernHelper.renderEffects(tooltip, effects); //from core.js
 				EmbassyButtonHelper.renderResourceChances(tooltip, controller.game, model.options.race);
 			}
 
@@ -1119,7 +1133,6 @@ var EmbassyButtonHelper = {
 						fontStyle: "italic"
 				}}, tooltip);
 			}
-
 		} else {
 			dojo.style(descDiv, "paddingBottom", "4px");
 		}
@@ -1167,6 +1180,7 @@ var EmbassyButtonHelper = {
 			className: "tooltip-divider" + " resEffectsTxt",
 			style: {
 				textAlign: "center",
+				clear: "both",
 				width: "100%",
 				borderBottom: "1px solid gray",
 				paddingBottom: "4px",

--- a/js/prestige.js
+++ b/js/prestige.js
@@ -98,7 +98,8 @@ dojo.declare("classes.managers.PrestigeManager", com.nuclearunicorn.core.TabMana
 			"perks": ["divineProportion"]
 		},
 		effects:{
-			"priceRatio" : -(1 + Math.sqrt(5)) / 200	//Calculates the Golden Ratio
+			"priceRatio" : -(1 + Math.sqrt(5)) / 200,	//Calculates the Golden Ratio
+			"queueCap": 1
 		}
 	},{
 		name: "divineProportion",
@@ -111,7 +112,8 @@ dojo.declare("classes.managers.PrestigeManager", com.nuclearunicorn.core.TabMana
 			"perks": ["vitruvianFeline"]
 		},
 		effects:{
-			"priceRatio" : -16 / 900
+			"priceRatio" : -16 / 900,
+			"queueCap": 2
 		}
 	},{
 		name: "vitruvianFeline",
@@ -134,7 +136,8 @@ dojo.declare("classes.managers.PrestigeManager", com.nuclearunicorn.core.TabMana
 		unlocked: false,
 		researched: false,
 		effects:{
-			"priceRatio" : -0.0225
+			"priceRatio" : -0.0225,
+			"queueCap": 2
 		}
 	},{
 		name: "diplomacy",

--- a/js/science.js
+++ b/js/science.js
@@ -1067,7 +1067,9 @@ dojo.declare("classes.managers.ScienceManager", com.nuclearunicorn.core.TabManag
 			{name : "culture", val: 150000}
 		],
 		effects:{
-			"technocracyScienceCap": 0.2
+			"technocracyScienceCap": 0.2,
+			"antimatterPolicyRatio": 0.05,
+			"queueCap": 2
 		},
 		unlocked: false,
 		blocked: false,

--- a/js/science.js
+++ b/js/science.js
@@ -1068,7 +1068,7 @@ dojo.declare("classes.managers.ScienceManager", com.nuclearunicorn.core.TabManag
 		],
 		effects:{
 			"technocracyScienceCap": 0.2,
-			"antimatterPolicyRatio": 0.05,
+			"antimatterPolicyRatio": 0.0625,
 			"queueCap": 2
 		},
 		unlocked: false,

--- a/js/space.js
+++ b/js/space.js
@@ -186,6 +186,7 @@ dojo.declare("classes.managers.SpaceManager", com.nuclearunicorn.core.TabManager
 			{name: "thorium",   val: 50000}
 		],
 		unlocks: {
+			challenges: ["energy"],
 			planet: ["centaurusSystem"],
 			spaceMission: ["furthestRingMission"]
 		}

--- a/js/time.js
+++ b/js/time.js
@@ -1822,7 +1822,7 @@ dojo.declare("classes.queue.manager", null,{
         }
     },
     cap: 0,
-    baseCap :2,
+    baseCap: 3,
 
     constructor: function(game){
         this.game = game;

--- a/js/workshop.js
+++ b/js/workshop.js
@@ -2621,9 +2621,14 @@ dojo.declare("classes.managers.WorkshopManager", com.nuclearunicorn.core.TabMana
 
 		var cultureBonusRaw = Math.floor(this.game.resPool.get("manuscript").value);
 		this.effectsBase["cultureMax"] = this.game.getUnlimitedDR(cultureBonusRaw, 0.01);
-		this.effectsBase["faithMax"] = this.game.getUnlimitedDR(cultureBonusRaw, 0.02) * this.game.getEffect("faithFromManuscripts");
-
 		this.effectsBase["cultureMax"] *= 1 + this.game.getEffect("cultureFromManuscripts");
+
+		var faithFromManuscripts = this.game.getEffect("faithFromManuscripts");
+		if (faithFromManuscripts > 0) {
+			this.effectsBase["faithMax"] = this.game.getLimitedDR(this.game.getUnlimitedDR(cultureBonusRaw, 0.1) * faithFromManuscripts, 100000);
+		} else {
+			this.effectsBase["faithMax"] = 0;
+		}
 
 		//sanity check
 		if (this.game.village.getFreeEngineers() < 0){

--- a/res/i18n/en.json
+++ b/res/i18n/en.json
@@ -877,7 +877,7 @@
     "policy.sharkRelationsMerchants.label" : "Shark Relations: Merchants",
     "policy.sharkRelationsMerchants.desc" : "The sharks are experts of traveling through water, but not so much on land. Work together with their merchants to discover and share trade routes through water and land.<br>The more you trade, the more effective it becomes",
     "policy.siphoning.label" : "Siphoning",
-    "policy.siphoning.desc" : "Pacts consume alicorns and slow down corruption instead of consuming necrocorns. Lack of alicorns or corruption is compensated by consuming necrocorns.",
+    "policy.siphoning.desc" : "Pacts slow down necrocorn corruption and consume alicorns, instead of directly consuming necrocorns. Lack of alicorns or corruption is compensated by consuming necrocorns.",
     "policy.socialism.label" : "Socialism",
     "policy.socialism.desc" : "Has no effect",
     "policy.spaceBasedTerraforming.label" : "Space-based terraforming",

--- a/res/i18n/en.json
+++ b/res/i18n/en.json
@@ -383,6 +383,7 @@
     "effectsMgr.statics.aiCoreUpgradeBonus.title" : "AI core synergies bonuses",
     "effectsMgr.statics.aiLevel.title": "AI Level",
     "effectsMgr.statics.alicornChance.title": "Alicorns descent chance",
+    "effectsMgr.statics.antimatterPolicyRatio.title": "Antimatter production bonus",
     "effectsMgr.statics.antimatterProduction.title": "Antimatter production",
     "effectsMgr.statics.arrivalSlowdown.title": "Arrival slowdown",
     "effectsMgr.statics.barnRatio.title": "Barn expansion",

--- a/test/game.test.js
+++ b/test/game.test.js
@@ -516,7 +516,7 @@ test("Queue should correctly add and remove items", () => {
     let isRemoved;
 
     queue.update();
-    expect(queue.cap).toBe(2);
+    expect(queue.cap).toBe(3);
 
     //simple add and remove operations should work and keep queue clear
     queue.addToQueue("field", "buildings", "N/A");
@@ -535,9 +535,10 @@ test("Queue should correctly add and remove items", () => {
     //multiple items should stack into one queue entry
     queue.addToQueue("field", "buildings", "N/A");
     queue.addToQueue("field", "buildings", "N/A");
+    queue.addToQueue("field", "buildings", "N/A");
 
     expect(queue.queueItems.length).toBe(1); 
-    expect(queue.queueLength()).toBe(2);
+    expect(queue.queueLength()).toBe(3);
 
     //can't build over the cap
     queue.addToQueue("pasture", "buildings", "N/A");
@@ -549,12 +550,14 @@ test("Queue should correctly add and remove items", () => {
     queue.update();
 
     //multiple entires of the same type should be allowed
-    expect(queue.cap).toBe(12);
+    expect(queue.cap).toBe(13);
     queue.addToQueue("pasture", "buildings", "N/A");
     queue.addToQueue("field", "buildings", "N/A");
     expect(queue.queueItems.length).toBe(3);
     
     //sequential removals should decrement queue, and then clean items
+    queue.remove(0, 1);
+    expect(queue.queueItems.length).toBe(3);
     queue.remove(0, 1);
     expect(queue.queueItems.length).toBe(3);
     queue.remove(0, 1);
@@ -568,11 +571,11 @@ test("Queue should correctly add and remove items", () => {
 
     //test shift key option
     queue.addToQueue("field", "buildings", "N/A", true /*all available*/);
-    expect(queue.queueLength()).toBe(12);
+    expect(queue.queueLength()).toBe(13);
     expect(queue.queueItems.length).toBe(2);
 
     //console.error(queue.queueItems);
-    expect(queue.queueItems[1].value).toBe(11);
+    expect(queue.queueItems[1].value).toBe(12);
 });
 
 test("Queue should correctly skip one-time purchases if already bought", () => {


### PR DESCRIPTION
### Policy stuff:
- Heavy nerf to Lizard Priests in the late-game, keeping it somewhat strong in the early-game.  The UDR is capped at a threshold which scales based on max faith from buildings; beyond this threshold, there is logarithmic scaling.
- Small buff to Autocracy (Mints benefit from it at reduced strength)
- Buff to Technocracy (+5% AM production, +2 queue cap)
- Reword description for Siphoning, credit goes to Antipatience
- In Iron Will, 1/3 of the bonus from Strip Mining will affect meteors.
- In Iron Will, 1/3 of the bonus from Clear Cutting will affect wood crafting.
- Naga Embassies will show the effect from Naga Architects in their tooltip, if relevant.
### Non-policy stuff:
- Increase difficulty of unlocking Energy Challenge (will remain unlocked for players who have it already)
- Some Price Ratio Metas now grant queue cap (total of +5)
- Increase base queue cap (2 → 3)
- Disable `SPACE_EXPL` features on beta