### PR TITLE
Fix duplicate expInfo in census UI on web

### DIFF
--- a/game.js
+++ b/game.js
@@ -2093,7 +2093,7 @@ dojo.declare("com.nuclearunicorn.game.ui.GamePage", null, {
 		];
 
 		if (this.isMobile()){
-			this.tabRegistry.push(
+			tabRegistry.push(
 				{
 					class: classes.tab.QueueTab,
 					name: "tab.name.queue",
@@ -5162,6 +5162,11 @@ dojo.declare("com.nuclearunicorn.game.ui.GamePage", null, {
 			if (this.tabs[i].tabId.toLowerCase() == tabName){
 				return this.tabs[i];
 			}
+		}
+		//Hack because QueueTab is a tab that exists only on mobile
+		if (tabName == "queue" && !this.isMobile()) {
+			//We have to return *something* so it doesn't throw an error
+			return { tabName: "dummy tab", tabId: "Queue", visible: false };
 		}
 	},
 

--- a/js/time.js
+++ b/js/time.js
@@ -226,7 +226,7 @@ dojo.declare("classes.managers.TimeManager", com.nuclearunicorn.core.TabManager,
         return numberEvents;
     },
     calculateRedshift: function(){
-        var isRedshiftEnabled = this.game.opts.enableRedshift;
+        var isRedshiftEnabled = this.game.isMobile() ? true : this.game.opts.enableRedshift;
 
         var currentTimestamp = Date.now();
         var delta = isRedshiftEnabled
@@ -1405,7 +1405,7 @@ dojo.declare("classes.ui.time.ChronoforgeBtnController", com.nuclearunicorn.game
         var label = this.inherited(arguments);
 
         if (meta.heat){
-            return label + "<div class='progress'>[" + this.game.getDisplayValueExt(meta.heat) + "%]</div>";
+            return label + "<div class=\"progress\">[" + this.game.getDisplayValueExt(meta.heat) + "%]</div>";
         }
         return label;
     },

--- a/js/village.js
+++ b/js/village.js
@@ -4000,8 +4000,13 @@ dojo.declare("classes.ui.village.Census", null, {
 				? $I("village.census.trait.none")
 				: leader.trait.title + " (" + $I("village.bonus.desc." + leader.trait.name) + ") [" + $I("village.census.rank") + " " + leader.rank + "]";
 			var nextRank = Math.floor(this.game.village.getRankExp(leader.rank));
-			retVal.leaderInfo = this.game.village.getStyledName(leader, true /*is leader panel*/) + ", " + title +
-				"<br /> exp: " + this.game.getDisplayValueExt(leader.exp);
+			retVal.leaderInfo = this.game.village.getStyledName(leader, true /*is leader panel*/) + ", " + title;
+			//This is an ugly hack for mobile.
+			// Web uses expInfo, but mobile only uses leaderInfo.
+			//So put experience-related information inside leaderInfo for the benefit of mobile.
+			if (this.game.isMobile()) {
+				retVal.leaderInfo += "<br /> exp: " + this.game.getDisplayValueExt(leader.exp);
+			}
 
 			//exp & percentage to next rank
 			var nextRank = Math.floor(this.game.village.getRankExp(leader.rank));

--- a/res/i18n/en.json
+++ b/res/i18n/en.json
@@ -735,7 +735,6 @@
     "opts.theme": "Color theme",
     "opts.theme.anthracite": "Anthracite",
     "opts.theme.arctic": "Arctic",
-    "opts.theme.black": "Black",
     "opts.theme.bluish": "Bluish",
     "opts.theme.catnip": "Catnip",
     "opts.theme.chocolate": "Chocolate",
@@ -783,7 +782,7 @@
     "opts.enableKS": "Enable Kittens Scientist",
     "opts.enableKS.desc": "This is absolutely unsupported, you have never seen me or this setting",
 
-    "msg.necrocornDeficit.info": "Necrocorn deficit: {0}. Due to the deficit your pacts have {1}% effectivness. Deficit is consuming additional {2}% of necrocorns per day and is deminishing {3} per day (if you have enough necrocorns).",
+    "msg.necrocornDeficit.info": "Necrocorn deficit: {0}. Due to the deficit your pacts have {1}% effectivness. Deficit is consuming additional {2}% of necrocorns per day and is diminishing {3} per day (if you have enough necrocorns).",
     "msg.pacts.info": "Karma kittens per millenia are based on available pacts. Pacts do not persist. Available pacts: {0}. Every pact devours {1} necrocorns per day.",
     "msg.pacts.fractured": "You didn't fulfill your part of the deal... You lost {0} alicorns!",
     "opts.swipeNavigation": "Swipe navigation",
@@ -1857,7 +1856,7 @@
     "ui.option.notation": "Notation:",
     "ui.option.pollution": "Disable pollution effects",
 
-    "queue.alphabeticalToggle": "Sort queue items by alphabet",
+    "queue.alphabeticalToggle": "Sort queue items alphabetically",
     "queue.add": "Add to queue",
 
     "left.resources": "resources",


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/73892724-20a3-4d3a-9f09-32352baaa38e)

- (See image for what the duplicate expInfo looked like)
- Fixed this by adding a hack in village.js because I saw that the KGM code expects certain behavior from getGovernmentInfo

### game.js
- tabRegistry is a local variable, not a member of game.  This would (probably) have made queue tab not register properly on mobile.
- On web, a console error appears when processing the unlocking of the queue tab.  Fixed it with an ugly hack.  If you can think of a better way to deal with this, let's do it the better way instead.

### time.js
- isRedshiftEnabled looked dangerous to me, as if any change to that part of the code would propagate from here to the KGM repository & break the intended behavior on mobile.  Since there now is an isMobile function, let's use that to correctly handle both web & mobile behavior for isRedshiftEnabled.
- Replaced single quotes with double quotes in ChronoforgeBtnController to prevent unnecessary UI updates.

### en.json
- Fixed a spelling error that had been reintroduced
- Deleted duplicate entry for opts.theme.black