### PR TITLE
Fix ASCOH

### DIFF
--- a/js/challenges.js
+++ b/js/challenges.js
@@ -1097,7 +1097,6 @@ dojo.declare("classes.ui.ReservesPanel", com.nuclearunicorn.game.ui.Panel, {
 		if (resKit.length && this.game.prestige.getPerk("ascoh").researched) {
 			//Create a list of all the cryochambers we have stored in reserved & all kittens in them:
 			var kittensTable = dojo.create("table", {}, panelContainer);
-			var census = new classes.ui.village.Census(this.game);
 			for (var i = 0; i < resKit.length; i += 1) {
 				var kitten = resKit[i];
 	
@@ -1109,7 +1108,7 @@ dojo.declare("classes.ui.ReservesPanel", com.nuclearunicorn.game.ui.Panel, {
 					break;
 				}
 				//Otherwise, we still can display more kittens:
-				dojo.create("td", { innerHTML: census.getStyledName(kitten, false /*is leader panel*/), style: "padding-right: 8px" }, tr);
+				dojo.create("td", { innerHTML: this.game.village.getStyledName(kitten, false /*is leader panel*/), style: "padding-right: 8px" }, tr);
 				var traitLabel = kitten.trait.title;
 				var rank = kitten.rank;
 				//Note that if we are fractured, the name will be randomized, & we'll obscure other info as well.

--- a/js/jsx/queue.jsx.js
+++ b/js/jsx/queue.jsx.js
@@ -98,6 +98,9 @@ WQueueItem = React.createClass({
     isStorageLimited: function() {
         var game = this.props.game;
         var model = game.time.queue.getQueueElementModel(this.props.item);
+        if (!model) { //This might be an invalid queue item
+            return true; //Mark as storage-limited to try to get the player's attention
+        }
         return game.resPool.isStorageLimited(model.prices);
     }
 });

--- a/res/theme_catnip.css
+++ b/res/theme_catnip.css
@@ -880,6 +880,13 @@ body.scheme_catnip {
 	border: 1px solid rgba(0, 0 , 0, 0.25);
 	border-radius: 5px;
 }
+.scheme_catnip .tabInner.Challenges td.craftStuffPanel + td.craftStuffPanel > table { /* list of kittens in reserve */
+	background-color: rgba(0 ,0 ,0 , 0.6); /* copied from census-block because inside we have a list of kitten names*/
+	border: 1px solid rgba(0, 0, 0, 0.1);
+	border-radius: 5px;
+	font-size: 0.9em;
+	color: #d6dacb;
+}
 
 /* ******************************************************** */
 /* ******************* ACHIEVEMENTS TAB ******************* */

--- a/res/theme_chocolate.css
+++ b/res/theme_chocolate.css
@@ -812,6 +812,13 @@ body.scheme_chocolate.with_background_image {
 	padding: 10px 20px; /* default padding-top: 20px; */
 	color: #120f0c;
 }
+.scheme_chocolate .tabInner.Challenges td.craftStuffPanel + td.craftStuffPanel > table { /* list of kittens in reserve */
+	background-color: rgba(36, 27, 19, 0.25); /* copied from census-block because inside we have a list of kitten names*/
+	border: 1px solid;
+	border-radius: 9px;
+	font-size: 0.9em;
+	color: #c0a787;
+}
 
 /**********************************************************/
 /******************** ACHIEVEMENTS TAB ********************/


### PR DESCRIPTION
- Fix a bug where the Reserves panel in the Challenges tab wouldn’t render properly if the player had ASCOH.
- Reformatted the Reserves panel in some color themes (Catnip & Chocolate) so it’s easier to read.
- There was a bug where if you import a savefile with nonexistent things in the queue, it’d brick the game.  I think I fixed it.  (This would happen, for example, if I had queued up some items on a dev branch, then switched to a branch without them)

Pictures of what the Reserves panel looked like before:
<img width="187" alt="fixASCOH_chocolate_pre" src="https://github.com/user-attachments/assets/b3334fbc-5fc2-439f-9a93-e1e0420dfb8e" />
<img width="194" alt="fixASCOH_catnip_pre" src="https://github.com/user-attachments/assets/cf2607e4-a7a7-44b7-b568-de573e987ba2" />

Now here's what the Reserves panel looks like:
<img width="302" alt="fixASCOH_chocolate_post" src="https://github.com/user-attachments/assets/2aa2fefc-d979-4823-ab1b-7c6e4291d663" />
<img width="320" alt="fixASCOH_catnip_post" src="https://github.com/user-attachments/assets/dc00e43a-0bbe-43b7-9a63-6d248540cc93" />
See?  The text is a little easier to read.