### PR TITLE
Make button borders unclickable

### DIFF
--- a/core.js
+++ b/core.js
@@ -865,15 +865,6 @@ dojo.declare("com.nuclearunicorn.game.ui.Button", com.nuclearunicorn.core.Contro
 		}
 
 		// locked structures are invisible
-		// if (this.model.visible){ // kuile clean up
-		// 	if (this.domNode.style.display === "none"){
-		// 		this.domNode.style.display = "block";
-		// 	}
-		// } else {
-		// 	if (this.domNode.style.display === "block"){
-		// 		this.domNode.style.display = "none";
-		// 	}
-		// }
 		if (this.model.visible){
 			if (this.borderWrapper.style.display === "none"){
 				this.borderWrapper.style.display = "block";
@@ -1892,7 +1883,6 @@ dojo.declare("com.nuclearunicorn.game.ui.BuildingBtn", com.nuclearunicorn.game.u
 		if((building.val > 9 || building.name.length > 10) && this.model.hasSellLink) {
 			//Steamworks and accelerator specifically can be too large when sell button is on
 			//(tested to support max 99 bld count)
-			// dojo.style(this.domNode,"font-size","103%"); // kuile clean up
 			dojo.addClass(this.domNode, "small-text");
 		}
 

--- a/core.js
+++ b/core.js
@@ -827,6 +827,7 @@ dojo.declare("com.nuclearunicorn.game.ui.Button", com.nuclearunicorn.core.Contro
 
 	domNode: null,
 	container: null,
+	borderWrapper: null,
 
 	tab: null,
 
@@ -864,34 +865,48 @@ dojo.declare("com.nuclearunicorn.game.ui.Button", com.nuclearunicorn.core.Contro
 		}
 
 		// locked structures are invisible
+		// if (this.model.visible){ // kuile clean up
+		// 	if (this.domNode.style.display === "none"){
+		// 		this.domNode.style.display = "block";
+		// 	}
+		// } else {
+		// 	if (this.domNode.style.display === "block"){
+		// 		this.domNode.style.display = "none";
+		// 	}
+		// }
 		if (this.model.visible){
-			if (this.domNode.style.display === "none"){
-				this.domNode.style.display = "block";
+			if (this.borderWrapper.style.display === "none"){
+				this.borderWrapper.style.display = "block";
 			}
 		} else {
-			if (this.domNode.style.display === "block"){
-				this.domNode.style.display = "none";
+			if (this.borderWrapper.style.display === "block"){
+				this.borderWrapper.style.display = "none";
 			}
 		}
 	},
 
 	updateEnabled: function(){
+		// both the button border and interior nodes need the correct class to display properly
 		if ( this.domNode ){
 			var hasClass = dojo.hasClass(this.domNode, "disabled");
 			var hasClassLimited = dojo.hasClass(this.domNode, "limited");
 			if (this.model.enabled){
 				if (hasClass){
 					dojo.removeClass(this.domNode, "disabled");
+					dojo.removeClass(this.borderWrapper, "disabled");
 				}
 				if (hasClassLimited){
 					dojo.removeClass(this.domNode, "limited");
+					dojo.removeClass(this.borderWrapper, "limited");
 				}
 			} else {
 				if (!hasClass){
 					dojo.addClass(this.domNode, "disabled");
+					dojo.addClass(this.borderWrapper, "disabled");
 				}
 				if (!hasClassLimited && this.model.resourceIsLimited){
 					dojo.addClass(this.domNode, "limited");
+					dojo.addClass(this.borderWrapper, "limited");
 				}
 			}			
 		}
@@ -921,8 +936,15 @@ dojo.declare("com.nuclearunicorn.game.ui.Button", com.nuclearunicorn.core.Contro
 
 		this.container = btnContainer;
 
-		this.domNode = dojo.create("div", {
+		/* to prevent the border being clickable, remove it from the button and wrap the
+		   button in a bordered div that allows clicks to pass through its interior      */
+		this.borderWrapper = dojo.create("div", {
 			style: {
+				// the wrapper's background generally does need to be transparent, but this causes issues with some themes
+				// the background and certain other styles are set as needed in the applicable css file
+				padding: "0",
+				width: "fit-content",
+				pointerEvents: "none",
 				position: "relative",
 				display: this.model.visible ? "block" : "none"
 			},
@@ -930,9 +952,17 @@ dojo.declare("com.nuclearunicorn.game.ui.Button", com.nuclearunicorn.core.Contro
 			tabIndex: 0
 		}, btnContainer);
 
+		this.domNode = dojo.create("div", {
+			style: {
+				border: "none",
+				pointerEvents: "auto",
+				margin: "0"
+			},
+		}, this.borderWrapper);
+
 		if (this.model.twoRow) {
-			dojo.style(this.domNode, "marginLeft", "auto");
-			dojo.style(this.domNode, "marginRight", "auto");
+			dojo.style(this.borderWrapper, "marginLeft", "auto");
+			dojo.style(this.borderWrapper, "marginRight", "auto");
 		}
 
 		this.buttonContent = dojo.create("div", {
@@ -946,10 +976,15 @@ dojo.declare("com.nuclearunicorn.game.ui.Button", com.nuclearunicorn.core.Contro
 			style: {}
 		}, this.buttonContent);
 
-		this.domNode.className = "btn nosel";
+		/* removing the border from the button div makes it smaller, so adjustments need 
+		   to be made on a per-theme basis via the btnInterior and btnWrapper classes to
+		   maintain the same appearance                                                  */
+		this.domNode.className = "btn nosel btnInterior";
+		this.borderWrapper.className = "btn nosel btnWrapper";
 
 		if (!this.model.enabled){
 			this.domNode.className += " disabled";
+			this.borderWrapper.className += " disabled";
 		}
 
 		this.updateVisible();
@@ -1507,6 +1542,7 @@ dojo.declare("com.nuclearunicorn.game.ui.ButtonModern", com.nuclearunicorn.game.
 
 	afterRender: function(){
 		dojo.addClass(this.domNode, "modern");
+		dojo.addClass(this.borderWrapper, "modern");
 
 		this.renderLinks();
 		this.attachTooltip(dojo.partial(this.getTooltipHTML(), this.controller, this.model));
@@ -1856,6 +1892,7 @@ dojo.declare("com.nuclearunicorn.game.ui.BuildingBtn", com.nuclearunicorn.game.u
 		if((building.val > 9 || building.name.length > 10) && this.model.hasSellLink) {
 			//Steamworks and accelerator specifically can be too large when sell button is on
 			//(tested to support max 99 bld count)
+			// dojo.style(this.domNode,"font-size","103%"); // kuile clean up
 			dojo.addClass(this.domNode, "small-text");
 		}
 
@@ -1945,16 +1982,20 @@ dojo.declare("com.nuclearunicorn.game.ui.BuildingBtn", com.nuclearunicorn.game.u
 
 			//--------------- style -------------
 			if(building.val > 9) {
-				dojo.style(this.domNode,"font-size","90%");
+				dojo.addClass(this.domNode, "small-text");
 			}
 
 			if (this.toggle || this.remove || this.add) {
 				dojo.removeClass(this.domNode, "bldEnabled");
+				dojo.removeClass(this.borderWrapper, "bldEnabled");
 				dojo.removeClass(this.domNode, "bldlackResConvert");
+				dojo.removeClass(this.borderWrapper, "bldlackResConvert");
 				if (building.lackResConvert) {
 					dojo.toggleClass(this.domNode, "bldlackResConvert", building.on > 0);
+					dojo.toggleClass(this.borderWrapper, "bldlackResConvert", building.on > 0);
 				} else {
 					dojo.toggleClass(this.domNode, "bldEnabled", building.on > 0);
+					dojo.toggleClass(this.borderWrapper, "bldEnabled", building.on > 0);
 				}
 			}
 

--- a/res/default.css
+++ b/res/default.css
@@ -248,7 +248,7 @@ select>option {
 }
 
 .btn.small-text span {
-    font-size: 90%;
+    font-size: 103%;
 }
 
 .btn a:hover {

--- a/res/theme_arctic.css
+++ b/res/theme_arctic.css
@@ -65,6 +65,9 @@ body.scheme_arctic.with_background_image {
 	background: no-repeat local top right url('img/theme_arctic_background_03.jpg'), transparent;
 	box-shadow: inset -1px 1px 2px #303030, inset 1px -1px 2px #a0a0a0, 1px -1px 3px #707070, 0 1px 0 #f0f0f0;
 }
+.scheme_arctic .btn.modern.disabled.btnInterior {
+	box-shadow: inset -1px 1px 2px #303030, inset 1px -1px 2px #a0a0a0;
+}
 .scheme_arctic .btn.modern.disabled:hover {
 	border-color: #909090;
 	background: no-repeat local bottom right url('img/theme_arctic_background_03.jpg');
@@ -85,6 +88,9 @@ body.scheme_arctic.with_background_image {
 	background-attachment: local;
 	background-position: top -16px left;
 	box-shadow: 1px 1px 2px #707070;
+}
+.scheme_arctic .btn.modern.btnWrapper {
+	background: transparent;
 }
 .scheme_arctic .btn.modern:not(.disabled):hover {
 	background-color: transparent;

--- a/res/theme_black.css
+++ b/res/theme_black.css
@@ -88,26 +88,50 @@ body.scheme_black {
 .scheme_black .btn.disabled.bldlackResConvert { /* color for lack resources convertion */
 	background: no-repeat border-box linear-gradient(90deg, #b00029 0%, #b00029 10px, transparent 12px, transparent 100%);
 }
+.scheme_black .btn.disabled.bldlackResConvert.btnInterior {
+	background: no-repeat border-box linear-gradient(90deg, #b00029 0%, #b00029 8px, transparent 10px, transparent 100%);
+}
 .scheme_black .btn.disabled.bldlackResConvert:hover {
 	background: no-repeat border-box linear-gradient(90deg, #b00029 0%, #b00029 10px, transparent 12px, transparent 100%);
+}
+.scheme_black .btn.disabled.bldlackResConvert.btnInterior:hover {
+	background: no-repeat border-box linear-gradient(90deg, #b00029 0%, #b00029 8x, transparent 10px, transparent 100%);
 }
 .scheme_black .btn:not(.disabled).bldlackResConvert {
 	background: no-repeat border-box linear-gradient(90deg, #b00029 0%, #b00029 10px, transparent 12px, transparent 100%);
 }
+.scheme_black .btn:not(.disabled).bldlackResConvert.btnInterior {
+	background: no-repeat border-box linear-gradient(90deg, #b00029 0%, #b00029 8px, transparent 10px, transparent 100%);
+}
 .scheme_black .btn:not(.disabled).bldlackResConvert:hover {
 	background: no-repeat border-box linear-gradient(90deg, #f9002b 0%, #f9002b 10px, #101010 12px, #101010 100%);
+}
+.scheme_black .btn:not(.disabled).bldlackResConvert.btnInterior:hover {
+	background: no-repeat border-box linear-gradient(90deg, #f9002b 0%, #f9002b 8px, #101010 10px, #101010 100%);
 }
 .scheme_black .btn.disabled.bldEnabled {
 	background: no-repeat border-box linear-gradient(90deg, #00801e 0%, #00801e 10px, transparent 12px, transparent 100%);
 }
+.scheme_black .btn.disabled.bldEnabled.btnInterior {
+	background: no-repeat border-box linear-gradient(90deg, #00801e 0%, #00801e 8px, transparent 10px, transparent 100%);
+}
 .scheme_black .btn.disabled.bldEnabled:hover {
 	background: no-repeat border-box linear-gradient(90deg, #00801e 0%, #00801e 10px, transparent 12px, transparent 100%);
+}
+.scheme_black .btn.disabled.bldEnabled.btnInterior:hover {
+	background: no-repeat border-box linear-gradient(90deg, #00801e 0%, #00801e 8px, transparent 10px, transparent 100%);
 }
 .scheme_black .btn:not(.disabled).bldEnabled {
 	background: no-repeat border-box linear-gradient(90deg, #00801e 0%, #00801e 10px, transparent 12px, transparent 100%);
 }
+.scheme_black .btn:not(.disabled).bldEnabled.btnInterior {
+	background: no-repeat border-box linear-gradient(90deg, #00801e 0%, #00801e 8px, transparent 10px, transparent 100%);
+}
 .scheme_black .btn:not(.disabled).bldEnabled:hover {
 	background: no-repeat border-box linear-gradient(90deg, #00b029 0%, #00b029 10px, #101010 12px, #101010 100%);
+}
+.scheme_black .btn:not(.disabled).bldEnabled.btnInterior:hover {
+	background: no-repeat border-box linear-gradient(90deg, #00b029 0%, #00b029 8px, #101010 10px, #101010 100%);
 }
 /*** end of green light for machine on/off ***/
 .scheme_black .dialog {

--- a/res/theme_catnip.css
+++ b/res/theme_catnip.css
@@ -61,6 +61,9 @@ body.scheme_catnip {
 	border: 1px solid rgba(0 ,0 ,0 , 0.1);
 	background-color: rgba(113, 148 , 64, 0.85);
 }
+.scheme_catnip .btn.modern.btnInterior {
+	background: transparent;
+}
 .scheme_catnip .btn.modern:not(.disabled):hover {
 	background-color: rgba(113, 148 , 64, 0.98);
 }
@@ -102,6 +105,10 @@ body.scheme_catnip {
 .scheme_catnip .modern .btnContent {
     padding: 10px 0 10px 1px; /* 1px left for buttons without power background-image */
 }
+.scheme_catnip .btn.modern.btnWrapper.disabled:hover {
+	background-color: transparent;
+	background: transparent;
+}
 /* *** green and red light for machine on/off *** */
 .scheme_catnip .btn.bldEnabled div.btnContent,
 .scheme_catnip .btn.bldlackResConvert div.btnContent {
@@ -131,6 +138,9 @@ body.scheme_catnip {
 }
 .scheme_catnip .btn:not(.disabled).bldEnabled:hover {
 	background: no-repeat linear-gradient(90deg, rgba(131, 203, 59, 0.98) 0, rgba(131, 203, 59, 0.98) 9px, transparent 12px, transparent 100%), rgba(113, 148 , 64, 0.98);
+}
+.scheme_catnip .btn.bldEnabled.btnInterior {
+	background: transparent;
 }
 /* *** end of green light for machine on/off *** */
 .scheme_catnip .dialog {

--- a/res/theme_chocolate.css
+++ b/res/theme_chocolate.css
@@ -26,6 +26,9 @@ body.scheme_chocolate.with_background_image {
 }
 .scheme_chocolate .btn,
 .scheme_chocolate .modern,
+.scheme_chocolate .btn.small-text span {
+    font-size: 97%;
+}
 .scheme_chocolate .btn.modern {
 	font-family: 'Ruluko', sans-serif;
 }
@@ -48,6 +51,10 @@ body.scheme_chocolate.with_background_image {
 	border-bottom-color: rgba(128, 128, 128, 0.6);
 	box-shadow: inset -1px -1px 3px rgba(180, 180, 180, 0.6), inset 2px 2px 3px #202020, 1px 1px 3px #101010;
 }
+.scheme_chocolate .btn.modern.disabled.btnInterior {
+	box-shadow: inset -1px -1px 3px rgba(180, 180, 180, 0.6), inset 2px 2px 3px #202020;
+	border-radius: 7px;
+}
 .scheme_chocolate .btn.modern.disabled:hover {
 	background-color: #c3ae99;
 	border: 2px solid rgba(160, 160, 160, 0.8);
@@ -66,6 +73,15 @@ body.scheme_chocolate.with_background_image {
 	border-bottom-color: rgba(217, 190, 163, 0.8);
 	box-shadow: inset 1px 1px 3px rgba(255, 255, 255, 0.4), inset -2px -2px 3px #202020,
 				1px 1px 3px #101010;
+}
+.scheme_chocolate .btn.modern:not(.disabled):not(.bldEnabled).btnInterior {
+	box-shadow: inset -1px -1px 3px rgba(180, 180, 180, 0.6), inset 2px 2px 3px #202020;
+}
+.scheme_chocolate .btn.modern:not(.disabled).bldEnabled.btnInterior {
+	box-shadow: inset 1px 1px 3px rgba(255, 255, 255, 0.4), inset -2px -2px 3px #202020
+}
+.scheme_chocolate .btn.modern:not(.disabled).bldEnabled.btnWrapper {
+	box-shadow: 1px 1px 3px #101010;
 }
 .scheme_chocolate .btn.modern:not(.disabled):hover {
 	background-color: #513c39;
@@ -119,26 +135,50 @@ body.scheme_chocolate.with_background_image {
 .scheme_chocolate .btn.disabled.bldlackResConvert { /* color #991A22 */ /* color for lack resources convertion */
 	background: no-repeat border-box linear-gradient(90deg, #930000 0%, #930000 10px, #c3ae99 12px, #c3ae99 100%);
 }
+.scheme_chocolate .btn.disabled.bldlackResConvert.btnInterior {
+	background: no-repeat border-box linear-gradient(90deg, #930000 0%, #930000 8px, #c3ae99 10px, #c3ae99 100%);
+}
 .scheme_chocolate .btn.disabled.bldlackResConvert:hover {
 	background: no-repeat border-box linear-gradient(90deg, #c30000 0%, #c30000 10px, #c3ae99 12px, #c3ae99 100%);
+}
+.scheme_chocolate .btn.disabled.bldlackResConvert.btnInterior:hover {
+	background: no-repeat border-box linear-gradient(90deg, #c30000 0%, #c30000 8px, #c3ae99 10px, #c3ae99 100%);
 }
 .scheme_chocolate .btn:not(.disabled).bldlackResConvert {
 	background: no-repeat border-box linear-gradient(90deg, #930000 0%, #930000 10px, #2f2220 12px, #2f2220 100%);
 }
+.scheme_chocolate .btn:not(.disabled).bldlackResConvert.btnInterior {
+	background: no-repeat border-box linear-gradient(90deg, #930000 0%, #930000 8px, #2f2220 10px, #2f2220 100%);
+}
 .scheme_chocolate .btn:not(.disabled).bldlackResConvert:hover {
 	background: no-repeat border-box linear-gradient(90deg, #c30000 0%, #c30000 10px, #513c39 12px, #513c39 100%);
+}
+.scheme_chocolate .btn:not(.disabled).bldlackResConvert.btnInterior:hover {
+	background: no-repeat border-box linear-gradient(90deg, #c30000 0%, #c30000 8px, #513c39 10px, #513c39 100%);
 }
 .scheme_chocolate .btn.disabled.bldEnabled { /* color #7AA738 */
 	background: no-repeat border-box linear-gradient(90deg, #a7da58 0%, #a7da58 10px, #c3ae99 12px, #c3ae99 100%);
 }
+.scheme_chocolate .btn.disabled.bldEnabled.btnInterior {
+	background: no-repeat border-box linear-gradient(90deg, #a7da58 0%, #a7da58 8px, #c3ae99 10px, #c3ae99 100%);
+}
 .scheme_chocolate .btn.disabled.bldEnabled:hover {
 	background: no-repeat border-box linear-gradient(90deg, #c8e896 0%, #c8e896 10px, #c3ae99 12px, #c3ae99 100%);
+}
+.scheme_chocolate .btn.disabled.bldEnabled.btnInterior:hover {
+	background: no-repeat border-box linear-gradient(90deg, #c8e896 0%, #c8e896 8px, #c3ae99 10px, #c3ae99 100%);
 }
 .scheme_chocolate .btn:not(.disabled).bldEnabled {
 	background: no-repeat border-box linear-gradient(90deg, #a7da58 0%, #a7da58 10px, #2f2220 12px, #2f2220 100%);
 }
+.scheme_chocolate .btn:not(.disabled).bldEnabled.btnInterior {
+	background: no-repeat border-box linear-gradient(90deg, #a7da58 0%, #a7da58 8px, #2f2220 10px, #2f2220 100%);
+}
 .scheme_chocolate .btn:not(.disabled).bldEnabled:hover {
 	background: no-repeat border-box linear-gradient(90deg, #c8e896 0%, #c8e896 10px, #513c39 12px, #513c39 100%);
+}
+.scheme_chocolate .btn:not(.disabled).bldEnabled.btnInterior:hover {
+	background: no-repeat border-box linear-gradient(90deg, #c8e896 0%, #c8e896 8px, #513c39 10px, #513c39 100%);
 }
 /*** end of green light for machine on/off ***/
 .scheme_chocolate .dialog { /* window options, credits and get the app */

--- a/res/theme_computer.css
+++ b/res/theme_computer.css
@@ -124,26 +124,50 @@ body.scheme_computer {
 .scheme_computer .btn.disabled.bldlackResConvert { /* color for lack resources convertion */
 	background: no-repeat border-box linear-gradient(90deg, #f05858 0%, #f05858 12px, #313131 15px, #313131 100%);
 }
+.scheme_computer .btn.disabled.bldlackResConvert.btnInterior {
+	background: no-repeat border-box linear-gradient(90deg, #f05858 0%, #f05858 10px, #313131 13px, #313131 100%);
+}
 .scheme_computer .btn.disabled.bldlackResConvert:hover {
 	background: no-repeat border-box linear-gradient(90deg, #ec3131 0%, #ec3131 12px, #313131 15px, #313131 100%);
+}
+.scheme_computer .btn.disabled.bldlackResConvert.btnInterior:hover {
+	background: no-repeat border-box linear-gradient(90deg, #ec3131 0%, #ec3131 10px, #313131 13px, #313131 100%);
 }
 .scheme_computer .btn:not(.disabled).bldlackResConvert {
 	background: no-repeat border-box linear-gradient(90deg, #f05858 0%, #f05858 12px, #7a8490 15px, #7a8490 100%);
 }
+.scheme_computer .btn:not(.disabled).bldlackResConvert.btnInterior {
+	background: no-repeat border-box linear-gradient(90deg, #f05858 0%, #f05858 10px, #7a8490 13px, #7a8490 100%);
+}
 .scheme_computer .btn:not(.disabled).bldlackResConvert:hover {
 	background: no-repeat border-box linear-gradient(90deg, #ec3131 0%, #ec3131 12px, #6b7480 15px, #6b7480 100%);
+}
+.scheme_computer .btn:not(.disabled).bldlackResConvert.btnInterior:hover {
+	background: no-repeat border-box linear-gradient(90deg, #ec3131 0%, #ec3131 10px, #6b7480 13px, #6b7480 100%);
 }
 .scheme_computer .btn.disabled.bldEnabled {
 	background: no-repeat border-box linear-gradient(90deg, #58f063 0%, #58f063 12px, #313131 15px, #313131 100%);
 }
+.scheme_computer .btn.disabled.bldEnabled.btnInterior {
+	background: no-repeat border-box linear-gradient(90deg, #58f063 0%, #58f063 10px, #313131 13px, #313131 100%);
+}
 .scheme_computer .btn.disabled.bldEnabled:hover {
 	background: no-repeat border-box linear-gradient(90deg, #30ec3e 0%, #30ec3e 12px, #313131 15px, #313131 100%);
+}
+.scheme_computer .btn.disabled.bldEnabled.btnInterior:hover {
+	background: no-repeat border-box linear-gradient(90deg, #30ec3e 0%, #30ec3e 10px, #313131 13px, #313131 100%);
 }
 .scheme_computer .btn:not(.disabled).bldEnabled {
 	background: no-repeat border-box linear-gradient(90deg, #58f063 0%, #58f063 12px, #7a8490 15px, #7a8490 100%);
 }
+.scheme_computer .btn:not(.disabled).bldEnabled.btnInterior {
+	background: no-repeat border-box linear-gradient(90deg, #58f063 0%, #58f063 10px, #7a8490 13px, #7a8490 100%);
+}
 .scheme_computer .btn:not(.disabled).bldEnabled:hover {
 	background: no-repeat border-box linear-gradient(90deg, #30ec3e 0%, #30ec3e 12px, #6b7480 15px, #6b7480 100%);
+}
+.scheme_computer .btn:not(.disabled).bldEnabled.btnInterior:hover {
+	background: no-repeat border-box linear-gradient(90deg, #30ec3e 0%, #30ec3e 10px, #6b7480 13px, #6b7480 100%);
 }
 /* *** end of green light for machine on/off *** */
 .scheme_computer .dialog {

--- a/res/theme_dune.css
+++ b/res/theme_dune.css
@@ -100,9 +100,6 @@ body.scheme_dune {
 .scheme_dune h1:first-child {
     margin-top: 15px;
 }
-/* .scheme_dune .btn.modern.small-text {
-	font-size: 100%; /* default font-size: 90%; 
-} */
 .scheme_dune .modern .btnContent {
     padding: 10px 0 10px 1px; /* 1px left for buttons without power background-image */
 }

--- a/res/theme_dune.css
+++ b/res/theme_dune.css
@@ -22,6 +22,10 @@ body.scheme_dune {
 .scheme_dune input[type='button'] {
 	font-family: 'Signika Negative', sans-serif;
 }
+.scheme_dune .btn.small-text span,
+.scheme_dune .btn.small-text a {
+	font-size: 93%;
+}
 .scheme_dune .btn {
 	color: gray;
 	margin-bottom: 3px; /* default 10px */
@@ -96,41 +100,69 @@ body.scheme_dune {
 .scheme_dune h1:first-child {
     margin-top: 15px;
 }
-.scheme_dune .btn.modern.small-text {
-	font-size: 100% !important; /* default font-size: 90%; */
-}
+/* .scheme_dune .btn.modern.small-text {
+	font-size: 100%; /* default font-size: 90%; 
+} */
 .scheme_dune .modern .btnContent {
     padding: 10px 0 10px 1px; /* 1px left for buttons without power background-image */
+}
+.scheme_dune div.modern.small-text.disabled:not(.bldEnabled):not(.bldlackResConvert) > div.btnContent,
+.scheme_dune div.modern.small-text:not(.disabled):not(.bldEnabled):not(.bldlackResConvert) > div.btnContent {
+	padding: 9px 0 10px 1px;
 }
 /* *** green and red light for machine on/off *** */
 .scheme_dune .btn.bldEnabled div.btnContent,
 .scheme_dune .btn.bldlackResConvert div.btnContent {
-	padding: 10px 0 10px 13px; /* 13px left for power background-image (linear-gradient) */
+	padding: 9px 0 10px 13px; /* 13px left for power background-image (linear-gradient) */
 	border: none; /* also allows you to remove the height difference with the other buttons (they have no border on div.content) */
 }
 .scheme_dune .btn.disabled.bldlackResConvert { /* color for lack resources convertion */
 	background: no-repeat border-box linear-gradient(90deg, #ac0307 0%, #ac0307 10px, #281028 12px, #281028 100%);
 }
+.scheme_dune .btn.disabled.bldlackResConvert.btnInterior {
+	background: no-repeat border-box linear-gradient(90deg, #ac0307 0%, #ac0307 9px, #281028 11px, #281028 100%);
+}
 .scheme_dune .btn.disabled.bldlackResConvert:hover {
 	background: no-repeat border-box linear-gradient(90deg, #ac0307 0%, #ac0307 10px, #281028 12px, #281028 100%);
+}
+.scheme_dune .btn.disabled.bldlackResConvert.btnInterior:hover {
+	background: no-repeat border-box linear-gradient(90deg, #ac0307 0%, #ac0307 9px, #281028 11px, #281028 100%);
 }
 .scheme_dune .btn:not(.disabled).bldlackResConvert {
 	background: no-repeat border-box linear-gradient(90deg, #ac0307 0%, #ac0307 10px, #3a1d43 12px, #3a1d43 100%);
 }
+.scheme_dune .btn:not(.disabled).bldlackResConvert.btnInterior {
+	background: no-repeat border-box linear-gradient(90deg, #ac0307 0%, #ac0307 9px, #3a1d43 11px, #3a1d43 100%);
+}
 .scheme_dune .btn:not(.disabled).bldlackResConvert:hover {
 	background: no-repeat border-box linear-gradient(90deg, #ac0307 0%, #ac0307 10px, #572854 12px, #572854 100%);
+}
+.scheme_dune .btn:not(.disabled).bldlackResConvert.btnInterior:hover {
+	background: no-repeat border-box linear-gradient(90deg, #ac0307 0%, #ac0307 9px, #572854 11px, #572854 100%);
 }
 .scheme_dune .btn.disabled.bldEnabled { /* color #5cac03 */
 	background: no-repeat border-box linear-gradient(90deg, #5cac03 0%, #5cac03 10px, #281028 12px, #281028 100%);
 }
+.scheme_dune .btn.disabled.bldEnabled.btnInterior {
+	background: no-repeat border-box linear-gradient(90deg, #5cac03 0%, #5cac03 9px, #281028 11px, #281028 100%);
+}
 .scheme_dune .btn.disabled.bldEnabled:hover {
 	background: no-repeat border-box linear-gradient(90deg, #5cac03 0%, #5cac03 10px, #281028 12px, #281028 100%);
+}
+.scheme_dune .btn.disabled.bldEnabled.btnInterior:hover {
+	background: no-repeat border-box linear-gradient(90deg, #5cac03 0%, #5cac03 9px, #281028 11px, #281028 100%);
 }
 .scheme_dune .btn:not(.disabled).bldEnabled {
 	background: no-repeat border-box linear-gradient(90deg, #5cac03 0%, #5cac03 10px, #3a1d43 12px, #3a1d43 100%);
 }
+.scheme_dune .btn:not(.disabled).bldEnabled.btnInterior {
+	background: no-repeat border-box linear-gradient(90deg, #5cac03 0%, #5cac03 9px, #3a1d43 11px, #3a1d43 100%);
+}
 .scheme_dune .btn:not(.disabled).bldEnabled:hover {
 	background: no-repeat border-box linear-gradient(90deg, #5cac03 0%, #5cac03 10px, #572854 12px, #572854 100%);
+}
+.scheme_dune .btn:not(.disabled).bldEnabled.btnInterior:hover {
+	background: no-repeat border-box linear-gradient(90deg, #5cac03 0%, #5cac03 9px, #572854 11px, #572854 100%);
 }
 /* *** end of green light for machine on/off *** */
 .scheme_dune .dialog { /* window options, credits and get the app */
@@ -585,8 +617,11 @@ body.scheme_dune {
 	font-weight: 300;
 	line-height: 16px;
 	background-color: transparent;
-	padding: 10px 2px 10px 2px !important; /* default :  padding: 10px 6px 10px 6px !important; */
+	padding: 11px 2px 10px 2px !important; /* default :  padding: 10px 6px 10px 6px !important; */
 	text-shadow: none;
+}
+.scheme_dune div.btn.modern.btnInterior:not(.disabled):not(.bldEnabled):not(.bldlackResConvert) a {
+	padding-top: 10px !important;
 }
 .scheme_dune .btn.modern:not(.disabled) a {
 	color: #16bcb8;

--- a/res/theme_fluid.css
+++ b/res/theme_fluid.css
@@ -34,6 +34,10 @@ body.scheme_fluid,
 .scheme_fluid input[type='button'] {
 	font-family: 'Lato', sans-serif;
 }
+.scheme_fluid .btn.small-text span,
+.scheme_fluid .btn.small-text a {
+	font-size: 93%;
+}
 .scheme_fluid .btn {
 	color: gray;
 	margin-bottom: 8px; /* default margin-bottom: 10px; */
@@ -61,6 +65,10 @@ body.scheme_fluid,
                 0 1px 0 rgba(187, 192, 202, 0.4); /* color #BBC0CA */
 	cursor: inherit;
 }
+.scheme_fluid .btn.modern.disabled.btnWrapper,
+.scheme_fluid .btn.modern.disabled.btnWrapper:hover {
+	box-shadow: none;
+}
 .scheme_fluid .btn.modern.disabled span.btnTitle { /* to change only the properties of the button name for buttons disabled */
 	color: #000000;
 }
@@ -77,6 +85,10 @@ body.scheme_fluid,
 	border: solid 1px rgba(209, 214, 223, 0.7); /* color #D1D6DF */
 	box-shadow: none;
 	cursor: pointer;
+}
+.scheme_fluid .btn.modern:not(.disabled).btnInterior,
+.scheme_fluid .btn.modern:not(.disabled).btnInterior:hover {
+	box-shadow: none;
 }
 .scheme_fluid .census-block .links-container span,
 .scheme_fluid .btn.modern:not(.disabled) span.btnTitle { /* to change only the properties of the button name for buttons enabled */
@@ -116,35 +128,63 @@ body.scheme_fluid,
 .scheme_fluid .modern .btnContent {
     padding: 10px 0 10px 1px; /* 1px left for buttons without power background-image */
 }
+.scheme_fluid div.modern.small-text.disabled:not(.bldEnabled):not(.bldlackResConvert) > div.btnContent,
+.scheme_fluid div.modern.small-text:not(.disabled):not(.bldEnabled):not(.bldlackResConvert) > div.btnContent {
+	padding: 9px 0 10px 1px;
+}
 /*** green and red light for machine on/off ***/
 .scheme_fluid .btn.bldEnabled div.btnContent,
 .scheme_fluid .btn.bldlackResConvert div.btnContent {
 	border: none; /* also allows you to remove the height difference with the other buttons (they have no border on div.content) */
-	padding: 10px 0 10px 13px; /* 13px left for power background-image */
+	padding: 9px 0 10px 13px; /* 13px left for power background-image */
 }
 .scheme_fluid .btn.disabled.bldlackResConvert { /* color for lack resources convertion */
 	background: no-repeat border-box linear-gradient(90deg, #C24911 0%, #C24911 10px, #404040 12px, #404040 100%);
 }
+.scheme_fluid .btn.disabled.bldlackResConvert.btnInterior {
+	background: no-repeat border-box linear-gradient(90deg, #C24911 0%, #C24911 9px, #404040 11px, #404040 100%);
+}
 .scheme_fluid .btn.disabled.bldlackResConvert:hover {
 	background: no-repeat border-box linear-gradient(90deg, #C24911 0, #C24911 10px, #404040 12px, #404040 100%);
+}
+.scheme_fluid .btn.disabled.bldlackResConvert.btnInterior:hover {
+	background: no-repeat border-box linear-gradient(90deg, #C24911 0, #C24911 9px, #404040 11px, #404040 100%);
 }
 .scheme_fluid .btn:not(.disabled).bldlackResConvert {
 	background: no-repeat border-box linear-gradient(90deg, #C24911 0%, #C24911 10px, #666666 12px, #666666 100%);
 }
+.scheme_fluid .btn:not(.disabled).bldlackResConvert.btnInterior {
+	background: no-repeat border-box linear-gradient(90deg, #C24911 0%, #C24911 9px, #666666 11px, #666666 100%);
+}
 .scheme_fluid .btn:not(.disabled).bldlackResConvert:hover {
 	background: no-repeat border-box linear-gradient(90deg, #d34300 0, #d34300 10px, #118AC2 12px, #118AC2 100%);
+}
+.scheme_fluid .btn:not(.disabled).bldlackResConvert.btnInterior:hover {
+	background: no-repeat border-box linear-gradient(90deg, #d34300 0, #d34300 9px, #118AC2 11px, #118AC2 100%);
 }
 .scheme_fluid .btn.disabled.bldEnabled {
 	background: no-repeat border-box linear-gradient(90deg, #7AA738 0%, #7AA738 10px, #404040 12px, #404040 100%);
 }
+.scheme_fluid .btn.disabled.bldEnabled.btnInterior {
+	background: no-repeat border-box linear-gradient(90deg, #7AA738 0%, #7AA738 9px, #404040 11px, #404040 100%);
+}
 .scheme_fluid .btn.disabled.bldEnabled:hover {
 	background: no-repeat border-box linear-gradient(90deg, #7AA738 0, #7AA738 10px, #404040 12px, #404040 100%);
+}
+.scheme_fluid .btn.disabled.bldEnabled.btnInterior:hover {
+	background: no-repeat border-box linear-gradient(90deg, #7AA738 0, #7AA738 9px, #404040 11px, #404040 100%);
 }
 .scheme_fluid .btn:not(.disabled).bldEnabled {
 	background: no-repeat border-box linear-gradient(90deg, #7AA738 0%, #7AA738 10px, #666666 12px, #666666 100%);
 }
+.scheme_fluid .btn:not(.disabled).bldEnabled.btnInterior {
+	background: no-repeat border-box linear-gradient(90deg, #7AA738 0%, #7AA738 9px, #666666 11px, #666666 100%);
+}
 .scheme_fluid .btn:not(.disabled).bldEnabled:hover {
 	background: no-repeat border-box linear-gradient(90deg, #94dc23 0, #94dc23 10px, #118AC2 12px, #118AC2 100%);
+}
+.scheme_fluid .btn:not(.disabled).bldEnabled.btnInterior:hover {
+	background: no-repeat border-box linear-gradient(90deg, #94dc23 0, #94dc23 9px, #118AC2 11px, #118AC2 100%);
 }
 /*** end of green light for machine on/off ***/
 .scheme_fluid .dialog {
@@ -470,8 +510,11 @@ body.scheme_fluid,
 	color: #808080;
 	font-weight: 300;
 	background-color: transparent;
-	padding: 10px 3px 10px 3px !important; /* default :  padding: 10px 6px 10px 6px !important; */
+	padding: 11px 3px 10px 3px !important; /* default :  padding: 10px 6px 10px 6px !important; */
 	/* default min-width: 20px; */
+}
+.scheme_fluid div.btn.modern.btnInterior:not(.disabled):not(.bldEnabled):not(.bldlackResConvert) a {
+	padding-top: 10px !important;
 }
 .scheme_fluid .btn.modern:not(.disabled) a {
 	color: #202020;

--- a/res/theme_gold.css
+++ b/res/theme_gold.css
@@ -18,6 +18,13 @@ body.scheme_gold {
 .scheme_gold input[type='button'] {
     font-family: 'PT Sans', sans-serif;
 }
+.scheme_gold .btn.small-text span,
+.scheme_gold .btn.small-text a {
+	font-size: 83.6%;
+}
+.scheme_gold .btnWrapper {
+    background: transparent !important;
+}
 .scheme_gold .btn {
 	color: gray;
 	margin-bottom: 5px; /* default margin-bottom: 10px; */
@@ -94,30 +101,55 @@ body.scheme_gold {
 .scheme_gold .modern .btnContent {
     padding: 10px 0 10px 1px; /* 1px left for buttons without power background-image */
 }
+.scheme_gold .modern.small-text .btnContent {
+    padding: 8px 0 9px 1px;
+}
+.scheme_fluid div.modern.small-text.disabled:not(.bldEnabled):not(.bldlackResConvert) > div.btnContent,
+.scheme_fluid div.modern.small-text:not(.disabled):not(.bldEnabled):not(.bldlackResConvert) > div.btnContent {
+	padding: 8px 0 9px 1px;
+}
 /*** green and red light for machine on/off ***/
 .scheme_gold .btn.bldEnabled div.btnContent,
 .scheme_gold .btn.bldlackResConvert div.btnContent {
     border: none; /* also allows you to remove the height difference with the other buttons (they have no border on div.content) */
-    padding: 10px 0 10px 13px; /* 13px left for power background-image */
+    padding: 8px 0 9px 13px; /* 13px left for power background-image */
 }
 .scheme_gold .btn.disabled.bldlackResConvert {
 	/* color for lack resources convertion */
 	background: no-repeat border-box linear-gradient(90deg, #C83B00 0%, #C83B00 10px, rgba(32, 32, 32, 0.4) 12px, rgba(32, 32, 32, 0.4) 100%);
 }
+/* .scheme_gold .btn.disabled.bldlackResConvert.btnInterior {
+    background: no-repeat border-box linear-gradient(90deg, #C83B00 0%, #C83B00 9px, rgba(32, 32, 32, 0.4) 11px, rgba(32, 32, 32, 0.4) 100%);
+} */
 .scheme_gold .btn:not(.disabled).bldlackResConvert {
 	background: no-repeat border-box linear-gradient(90deg, #C83B00 0%, #C83B00 10px, rgba(87, 78, 64, 0.1) 12px, rgba(87, 78, 64, 0.1) 100%);
+}
+.scheme_gold .btn:not(.disabled).bldlackResConvert.btnInterior {
+    background: no-repeat border-box linear-gradient(90deg, #C83B00 0%, #C83B00 9px, rgba(87, 78, 64, 0.1) 11px, rgba(87, 78, 64, 0.1) 100%);
 }
 .scheme_gold .btn:not(.disabled).bldlackResConvert:hover {
 	background: no-repeat border-box linear-gradient(90deg, #C83B00 0%, #C83B00 10px, rgba(223, 206, 153, 0.3) 12px, rgba(223, 206, 153, 0.3) 100%);
 }
+.scheme_gold .btn:not(.disabled).bldlackResConvert.btnInterior:hover {
+    background: no-repeat border-box linear-gradient(90deg, #C83B00 0%, #C83B00 9px, rgba(223, 206, 153, 0.3) 11px, rgba(223, 206, 153, 0.3) 100%);
+}
 .scheme_gold .btn.disabled.bldEnabled {
 	background: no-repeat padding-box linear-gradient(90deg, #7CB342 0%, #7cb342 10px, rgba(32, 32, 32, 0.4) 12px, rgba(32, 32, 32, 0.4) 100%);
 }
+/* .scheme_gold .btn.disabled.bldEnabled.btnInterior {
+    background: no-repeat padding-box linear-gradient(90deg, #7CB342 0%, #7cb342 9px, rgba(32, 32, 32, 0.4) 11px, rgba(32, 32, 32, 0.4) 100%);
+} */
 .scheme_gold .btn:not(.disabled).bldEnabled {
 	background: no-repeat border-box linear-gradient(90deg, #7cb342 0%, #7cb342 10px, rgba(87, 78, 64, 0.1) 12px, rgba(87, 78, 64, 0.1) 100%);
 }
+.scheme_gold .btn:not(.disabled).bldEnabled.btnInterior {
+    background: no-repeat border-box linear-gradient(90deg, #7cb342 0%, #7cb342 9px, rgba(87, 78, 64, 0.1) 11px, rgba(87, 78, 64, 0.1) 100%);
+}
 .scheme_gold .btn:not(.disabled).bldEnabled:hover {
 	background: no-repeat border-box linear-gradient(90deg, #7cb342 0%, #7cb342 10px, rgba(223, 206, 153, 0.3) 12px, rgba(223, 206, 153, 0.3) 100%);
+}
+.scheme_gold .btn:not(.disabled).bldEnabled.btnInterior:hover {
+    background: no-repeat border-box linear-gradient(90deg, #7cb342 0%, #7cb342 9px, rgba(223, 206, 153, 0.3) 11px, rgba(223, 206, 153, 0.3) 100%);
 }
 /*** end of green light for machine on/off ***/
 .scheme_gold .dialog { /* window options, get the app and credits */
@@ -470,8 +502,11 @@ body.scheme_gold {
     font-weight: normal;
     line-height: 16px;
     background-color: rgba(209, 184, 107, 0.01); /* color #D1B86B */
-    padding: 10px 5px 10px 5px !important; /* default padding: 10px 6px 10px 6px !important; */
+    padding: 12px 5px 10px 5px !important; /* default padding: 10px 6px 10px 6px !important; */
     border-color: #645F4F; /* color pick from button not disabled and hover */
+}
+.scheme_gold .btn.modern:not(.bldEnabled):not(.small-text):not(.disabled) a {
+	padding-top: 10px !important;
 }
 .scheme_gold .btn.modern.disabled a {
     color: #725e55;

--- a/res/theme_grassy.css
+++ b/res/theme_grassy.css
@@ -30,6 +30,24 @@ body.scheme_grassy {
 	background: rgba(255, 255, 255, 0.2);
 }
 
+.scheme_grassy .btn.small-text span {
+	font-size: 94.3%;
+}
+.scheme_grassy .btn.small-text.modern div.btnContent {
+	padding: 9px 0 10px 10px;
+}
+.scheme_grassy .btn.modern.btnWrapper,
+.scheme_grassy .btn.modern.btnWrapper:hover {
+	background: transparent;
+}
+.scheme_grassy .btn.modern.btnWrapper.disabled:hover {
+	background-color: transparent !important;
+}
+.scheme_grassy .btn.small-text a {
+	margin: -9px 0;
+	font-size: 94.3%;
+}
+
 .scheme_grassy #headerLinks {
 	background: none;
 }

--- a/res/theme_minimalist.css
+++ b/res/theme_minimalist.css
@@ -28,6 +28,10 @@ body.scheme_minimalist.with_background_image,
 .scheme_minimalist input[type='button'] {
 	 font-family: 'Open Sans', sans-serif;
 }
+.scheme_minimalist .btn.small-text span,
+.scheme_minimalist .btn.small-text a {
+	font-size: 93%;
+}
 .scheme_minimalist .btn {
 	color: gray;
 	margin-bottom: 3px; /* default 10px */
@@ -110,35 +114,65 @@ body.scheme_minimalist.with_background_image,
 .scheme_minimalist .modern .btnContent {
     padding: 10px 0 10px 1px; /* 1px left for buttons without power background-image */
 }
+.scheme_minimalist .modern.small-text .btnContent {
+	padding: 9px 0 10px 1px;
+}
+.scheme_minimalist .btn.modern a {
+	margin: -9px 0;
+}
 /*** green and red light for machine on/off ***/
 .scheme_minimalist .btn.bldEnabled div.btnContent,
 .scheme_minimalist .btn.bldlackResConvert div.btnContent {
-	padding: 10px 0 10px 13px; /* 13px left for power background-image (linear-gradient) */
+	padding: 9px 0 10px 13px; /* 13px left for power background-image (linear-gradient) */
 	border: none; /* also allows you to remove the height difference with the other buttons (they have no border on div.content) */
 }
 .scheme_minimalist .btn.disabled.bldlackResConvert { /* color #be4151 */ /* color for lack resources convertion */
 	background: no-repeat border-box linear-gradient(90deg, #be4151 0%, #be4151 10px, #21212B 12px, #21212B 50%, #313140 95%, #313140 100%);
 }
+.scheme_minimalist .btn.disabled.bldlackResConvert.btnInterior {
+	background: no-repeat border-box linear-gradient(90deg, #be4151 0%, #be4151 9px, #21212B 11px, #21212B 50%, #313140 95%, #313140 100%);
+}
 .scheme_minimalist .btn.disabled.bldlackResConvert:hover {
 	background: no-repeat border-box linear-gradient(90deg, #be4151 0%, #be4151 10px, #21212B 12px, #21212B 100%);
+}
+.scheme_minimalist .btn.disabled.bldlackResConvert.btnInterior:hover {
+	background: no-repeat border-box linear-gradient(90deg, #be4151 0%, #be4151 9px, #21212B 11px, #21212B 100%);
 }
 .scheme_minimalist .btn:not(.disabled).bldlackResConvert {
 	background: no-repeat border-box linear-gradient(90deg, #be4151 0%, #be4151 10px, #41414C 12px, #41414C 50%, #51515E 95%, #51515E 100%);
 }
+.scheme_minimalist .btn:not(.disabled).bldlackResConvert.btnInterior {
+	background: no-repeat border-box linear-gradient(90deg, #be4151 0%, #be4151 9px, #41414C 11px, #41414C 50%, #51515E 95%, #51515E 100%);
+}
 .scheme_minimalist .btn:not(.disabled).bldlackResConvert:hover {
 	background: no-repeat border-box linear-gradient(90deg, #d0172a 0%, #d0172a 10px, #41414C 12px, #41414C 100%);
+}
+.scheme_minimalist .btn:not(.disabled).bldlackResConvert.btnInterior:hover {
+	background: no-repeat border-box linear-gradient(90deg, #d0172a 0%, #d0172a 9px, #41414C 11px, #41414C 100%);
 }
 .scheme_minimalist .btn.disabled.bldEnabled { /* color #5D743A */
 	background: no-repeat border-box linear-gradient(90deg, #5D743A 0%, #5D743A 10px, #21212B 12px, #21212B 50%, #313140 95%, #313140 100%);
 }
+.scheme_minimalist .btn.disabled.bldEnabled.btnInterior {
+	background: no-repeat border-box linear-gradient(90deg, #5D743A 0%, #5D743A 9px, #21212B 11px, #21212B 50%, #313140 95%, #313140 100%);
+}
 .scheme_minimalist .btn.disabled.bldEnabled:hover {
 	background: no-repeat border-box linear-gradient(90deg, #5D743A 0%, #5D743A 10px, #21212B 12px, #21212B 100%);
+}
+.scheme_minimalist .btn.disabled.bldEnabled.btnInterior:hover {
+	background: no-repeat border-box linear-gradient(90deg, #5D743A 0%, #5D743A 9px, #21212B 11px, #21212B 100%);
 }
 .scheme_minimalist .btn:not(.disabled).bldEnabled {
 	background: no-repeat border-box linear-gradient(90deg, #5D743A 0%, #5D743A 10px, #41414C 12px, #41414C 50%, #51515E 95%, #51515E 100%);
 }
+.scheme_minimalist .btn:not(.disabled).bldEnabled.btnInterior {
+	background: no-repeat border-box linear-gradient(90deg, #5D743A 0%, #5D743A 9px, #41414C 11px, #41414C 50%, #51515E 95%, #51515E 100%);
+}
 .scheme_minimalist .btn:not(.disabled).bldEnabled:hover {
 	background: no-repeat border-box linear-gradient(90deg, #90b23e 0%, #90b23e 10px, #41414C 12px, #41414C 100%);
+}
+.scheme_minimalist .btn:not(.disabled).bldEnabled.btnInterior:hover {
+	background: no-repeat border-box linear-gradient(90deg, #90b23e 0%, #90b23e 9px, #41414C 11px, #41414C 100%);
 }
 /*** end of green light for machine on/off ***/
 .scheme_minimalist,
@@ -587,6 +621,9 @@ body.scheme_minimalist.with_background_image,
 	background-color: transparent;
 	padding: 10px 2px 10px 2px !important; /* default :  padding: 10px 6px 10px 6px !important; */
 	text-shadow: none;
+}
+.scheme_minimalist .btn.modern:not(.bldEnabled):not(.disabled) a {
+	padding: 9px 2px 10px 2px !important;
 }
 .scheme_minimalist .btn.modern:not(.disabled) a {
 	color: #808799;

--- a/res/theme_oil.css
+++ b/res/theme_oil.css
@@ -28,6 +28,9 @@ body.scheme_oil,
 .scheme_oil .btn.modern {
 	font-family: 'Open Sans', sans-serif;
 }
+.scheme_oil .btn.small-text span {
+    font-size: 97%;
+}
 .scheme_oil .btn {
 	color: gray;
 	margin-bottom: 6px; /* default 10px */

--- a/res/theme_school.css
+++ b/res/theme_school.css
@@ -25,6 +25,12 @@ body.scheme_school.with_background_image,
 .scheme_school input[type='button'] {
 	font-family: 'Delius Swash Caps', cursive;
 }
+.scheme_school .btnWrapper {
+	background: transparent !important;
+}
+.scheme_school .btn.small-text span {
+    font-size: 83.6%;
+}
 .scheme_school .btn {
 	color: gray;
 	margin-bottom: 7px; /* default 10px */
@@ -33,6 +39,9 @@ body.scheme_school.with_background_image,
 	border: solid 1px transparent;
 	border-radius: 5px;
 }
+.scheme_school .btn.btnInterior {
+	border-radius: 4px;
+}
 .scheme_school .btn.modern.disabled {
 	background-color: rgba(85, 85, 85, 0.4); /* color #555555 */
 	border: solid 1px rgba(85, 85, 85, 0.1); /* color #555555 */
@@ -40,6 +49,9 @@ body.scheme_school.with_background_image,
 .scheme_school .btn.modern.disabled:hover {
 	background-color: rgba(85, 85, 85, 0.4); /* color #555555 */
 	border: solid 1px rgba(85, 85, 85, 0.7); /* color #555555 */
+}
+.scheme_school .btn.modern.disabled.btnWrapper {
+	border: solid 1px rgba(85, 85, 85, 0.5);
 }
 .scheme_school .btn.modern.disabled span.btnTitle { /* to change only the properties of the button name for buttons disabled */
 	color: #81848C;
@@ -57,6 +69,15 @@ body.scheme_school.with_background_image,
 	border: solid 1px rgba(209, 214, 223, 0.7); /* color #D1D6DF */
 	cursor: pointer;
 	box-shadow: 2px 2px 3px #000000;
+}
+.scheme_school .btn.modern.btnWrapper:not(.disabled) { 
+	border: solid 1px rgba(107, 112, 122, 0.6);
+}
+.scheme_school .btn.modern.btnWrapper:not(.disabled):hover {
+	border: solid 1px rgba(209, 214, 223, 0.7);
+}
+.scheme_school .btn.modern.btnWrapper.disabled:hover {
+	border: solid 1px rgba(85, 85, 85, 0.7);
 }
 .scheme_school .btn.modern:not(.disabled) span.btnTitle { /* to change only the properties of the button name for buttons enabled */
 	color: #ABAEB7;
@@ -94,35 +115,62 @@ body.scheme_school.with_background_image,
 .scheme_school .modern .btnContent {
     padding: 10px 0 10px 1px; /* 1px left for buttons without power background-image */
 }
+.scheme_school .modern.small-text .btnContent {
+	padding: 8px 0 9px 1px;
+}
 /*** green and red light for machine on/off ***/
 .scheme_school .btn.bldEnabled div.btnContent,
 .scheme_school .btn.bldlackResConvert div.btnContent {
-	padding: 10px 0 10px 15px; /* 15px left for power background-image (linear-gradient) */
+	padding: 8px 0 9px 15px; /* 15px left for power background-image (linear-gradient) */
 	border: none; /* also allows you to remove the height difference with the other buttons (they have no border on div.content) */
 }
 .scheme_school .btn.disabled.bldlackResConvert { /* color #973B47 */ /* color for lack resources convertion */
 	background: no-repeat border-box linear-gradient(90deg, #973B47 0%, #973B47 12px, rgba(85, 85, 85, 0.4) 14px, rgba(85, 85, 85, 0.4) 100%);
 }
+.scheme_school .btn.disabled.bldlackResConvert.btnInterior {
+	background: no-repeat border-box linear-gradient(90deg, #973B47 0%, #973B47 11px, rgba(85, 85, 85, 0.4) 13px, rgba(85, 85, 85, 0.4) 100%);
+}
 .scheme_school .btn.disabled.bldlackResConvert:hover {
 	background: no-repeat border-box linear-gradient(90deg, #973B47 0%, #973B47 12px, rgba(85, 85, 85, 0.4) 14px, rgba(85, 85, 85, 0.4) 100%);
+}
+.scheme_school .btn.disabled.bldlackResConvert.btnInterior:hover {
+	background: no-repeat border-box linear-gradient(90deg, #973B47 0%, #973B47 11px, rgba(85, 85, 85, 0.4) 13px, rgba(85, 85, 85, 0.4) 100%);
 }
 .scheme_school .btn:not(.disabled).bldlackResConvert {
 	background: no-repeat border-box linear-gradient(90deg, #973B47 0%, #973B47 12px, rgba(107, 112, 122, 0.5) 14px, rgba(107, 112, 122, 0.5) 100%);
 }
+.scheme_school .btn:not(.disabled).bldlackResConvert.btnInterior {
+	background: no-repeat border-box linear-gradient(90deg, #973B47 0%, #973B47 11px, rgba(107, 112, 122, 0.5) 13px, rgba(107, 112, 122, 0.5) 100%);
+}
 .scheme_school .btn:not(.disabled).bldlackResConvert:hover {
 	background: no-repeat border-box linear-gradient(90deg, #b74756 0%, #b74756 12px, rgba(107, 112, 122, 0.6) 14px, rgba(107, 112, 122, 0.6) 100%);
+}
+.scheme_school .btn:not(.disabled).bldlackResConvert.btnInterior:hover {
+	background: no-repeat border-box linear-gradient(90deg, #b74756 0%, #b74756 11px, rgba(107, 112, 122, 0.6) 13px, rgba(107, 112, 122, 0.6) 100%);
 }
 .scheme_school .btn.disabled.bldEnabled { /* color #3B7233 */
 	background: no-repeat border-box linear-gradient(90deg, #3B7233 0%, #3B7233 12px, rgba(85, 85, 85, 0.4) 14px, rgba(85, 85, 85, 0.4) 100%);
 }
+.scheme_school .btn.disabled.bldEnabled.btnInterior {
+	background: no-repeat border-box linear-gradient(90deg, #3B7233 0%, #3B7233 11px, rgba(85, 85, 85, 0.4) 13px, rgba(85, 85, 85, 0.4) 100%);
+}
 .scheme_school .btn.disabled.bldEnabled:hover {
 	background: no-repeat border-box linear-gradient(90deg, #3B7233 0%, #3B7233 12px, rgba(85, 85, 85, 0.4) 14px, rgba(85, 85, 85, 0.4) 100%);
+}
+.scheme_school .btn.disabled.bldEnabled.btnInterior:hover {
+	background: no-repeat border-box linear-gradient(90deg, #3B7233 0%, #3B7233 11px, rgba(85, 85, 85, 0.4) 13px, rgba(85, 85, 85, 0.4) 100%);
 }
 .scheme_school .btn:not(.disabled).bldEnabled {
 	background: no-repeat border-box linear-gradient(90deg, #3B7233 0%, #3B7233 12px, rgba(107, 112, 122, 0.5) 14px, rgba(107, 112, 122, 0.5) 100%);
 }
+.scheme_school .btn:not(.disabled).bldEnabled.btnInterior {
+	background: no-repeat border-box linear-gradient(90deg, #3B7233 0%, #3B7233 11px, rgba(107, 112, 122, 0.5) 13px, rgba(107, 112, 122, 0.5) 100%);
+}
 .scheme_school .btn:not(.disabled).bldEnabled:hover {
 	background: no-repeat border-box linear-gradient(90deg, #5eb252 0%, #5eb252 12px, rgba(107, 112, 122, 0.6) 14px, rgba(107, 112, 122, 0.6) 100%);
+}
+.scheme_school .btn:not(.disabled).bldEnabled.btnInterior:hover {
+	background: no-repeat border-box linear-gradient(90deg, #5eb252 0%, #5eb252 11px, rgba(107, 112, 122, 0.6) 13px, rgba(107, 112, 122, 0.6) 100%);
 }
 .scheme_school .dialog {
 	box-shadow: inset 0 1px 3px #000000;
@@ -452,7 +500,10 @@ body.scheme_school.with_background_image,
 	font-weight: 300;
 	color: #787d88;
 	background-color: transparent;
-	padding: 10px 3px 10px 3px !important; /* -1 pixel on vertical for correct align left border */
+	padding: 12px 3px 10px 3px !important; /* -1 pixel on vertical for correct align left border */
+}
+.scheme_school .btn.modern.btnInterior:not(.bldEnabled):not(.small-text) a {
+	padding: 10px 3px 10px 3px !important
 }
 .scheme_school .btn.modern:not(.disabled) a {
 	border-color: rgba(156, 159, 169, 0.1); /* color #9C9FA9 */

--- a/res/theme_sleek.css
+++ b/res/theme_sleek.css
@@ -671,3 +671,22 @@ body.scheme_sleek  {
 	padding-left: 28px;
 	font-weight: bold;
 }
+
+.scheme_sleek .btn.modern.btnWrapper {
+    background-color: transparent !important;
+    box-shadow: none !important;
+}
+.scheme_sleek .btn.small-text span,
+.scheme_sleek .btn.small-text a {
+    font-size: 90%;
+}
+.scheme_sleek .btn.modern.small-text .btnContent,
+.scheme_sleek .btn.modern.bldEnabled .btnContent {
+    padding: 9px 0 9px 10px;
+}
+.scheme_sleek .btnWrapper a {
+    margin: -9px 0;
+}
+.scheme_sleek .btnInterior:not(.bldEnabled):not(.small-text) a {
+    padding: 9px 6px 10px 6px !important;
+}

--- a/res/theme_space.css
+++ b/res/theme_space.css
@@ -23,6 +23,7 @@ body.scheme_space.with_background_image {
 .scheme_space input[type='button'] {
 	 font-family: 'Oxanium', cursive;
 }
+
 .scheme_space .btn {
 	color: black;
 	margin-bottom: 5px; /* default 10px */
@@ -66,6 +67,9 @@ body.scheme_space.with_background_image {
 	border: solid 1px rgba(20, 240, 216, 0.6);
  	cursor: pointer !important;
 }
+.scheme_space .btn.modern.nosel.btnWrapper {
+	background: transparent;
+}
 .scheme_space .census-block .links-container span,
 .scheme_space .btn.modern:not(.disabled) span.btnTitle { /* to change only the properties of the button name for buttons enabled */
 	color: #9FA5D6;
@@ -95,6 +99,31 @@ body.scheme_space.with_background_image {
 .scheme_space .disabled > div { /* color text on button disabled */
 	color: #9FA5D6;
 }
+.scheme_space .btn.small-text span,
+.scheme_space .btn.small-text a {
+    font-size: 92.6%;
+}
+.scheme_space .btn.modern.btnInterior.disabled.limited {
+	background-color: rgba(146, 0, 23, 0.15);
+}
+.scheme_space .btn.modern.btnWrapper:not(.disabled) {
+	border: solid 1px rgba(20, 240, 216, 0.28);
+}
+.scheme_space .btn.modern.btnWrapper.disabled:not(.limited) {
+	border-color: rgba(140, 140, 140, 0.28);
+}
+.scheme_space .btn.modern.btnInterior.bldEnabled.limited {
+	background: transparent;
+}
+.scheme_space .btn.modern a {
+	margin: -8px 0;
+}
+.scheme_space .btn.modern.btnInterior:not(.bldEnabled):not(.small-text) a {
+	padding: 8px 3px 9px 3px !important;
+}
+.scheme_space .btn.modern.btnWrapper.bldEnabled.disabled:not(.limited) {
+	background: transparent;
+}
 .scheme_space h1 {
     font-size: 100%;
     color: #C23574;
@@ -107,47 +136,86 @@ body.scheme_space.with_background_image {
 .scheme_space .modern .btnContent {
     padding: 10px 0 9px 1px; /* 1px left for buttons without power background-image */
 }
+.scheme_space .modern.small-text .btnContent {
+	padding: 8px 0 9px 1px;
+}
 /* *** green and red light for machine on/off *** */
 .scheme_space .btn.bldEnabled div.btnContent,
 .scheme_space .btn.bldlackResConvert div.btnContent {
-	padding: 10px 0 9px 13px; /* 13px left for power background-image (linear-gradient) */
+	padding: 8px 0 9px 13px; /* 13px left for power background-image (linear-gradient) */
 	border: none; /* also allows you to remove the height difference with the other buttons (they have no border on div.content) */
 }
 .scheme_space .btn.disabled.bldlackResConvert { /* color for lack resources convertion */
 	background: no-repeat border-box linear-gradient(90deg, #EA152C 0%, #EA152C 11px, rgba(140, 140, 140, 0.1) 12px, rgba(140, 140, 140, 0.1) 100%);
 }
+.scheme_space .btn.disabled.bldlackResConvert.btnInterior {
+	background: no-repeat border-box linear-gradient(90deg, #EA152C 0%, #EA152C 10px, rgba(140, 140, 140, 0.1) 11px, rgba(140, 140, 140, 0.1) 100%);
+}
 .scheme_space .btn.disabled.bldlackResConvert:hover {
 	background: no-repeat border-box linear-gradient(90deg, #EA152C 0%, #EA152C 11px, rgba(255, 255, 255, 0.1) 12px, rgba(255, 255, 255, 0.1) 100%);
+}
+.scheme_space .btn.disabled.bldlackResConvert.btnInterior:hover {
+	background: no-repeat border-box linear-gradient(90deg, #EA152C 0%, #EA152C 10px, rgba(255, 255, 255, 0.1) 11px, rgba(255, 255, 255, 0.1) 100%);
 }
 .scheme_space .btn.disabled.limited.bldlackResConvert {
 	background: no-repeat border-box linear-gradient(90deg, #EA152C 0%, #EA152C 11px, rgba(146, 0, 23, 0.1) 12px, rgba(146, 0, 23, 0.1) 100%);
 }
+.scheme_space .btn.disabled.limited.bldlackResConvert.btnInterior {
+	background: no-repeat border-box linear-gradient(90deg, #EA152C 0%, #EA152C 10px, rgba(146, 0, 23, 0.1) 11px, rgba(146, 0, 23, 0.1) 100%);
+}
 .scheme_space .btn.disabled.limited.bldlackResConvert:hover {
 	background: no-repeat border-box linear-gradient(90deg, #EA152C 0%, #EA152C 11px, rgba(234, 21, 44, 0.1) 12px, rgba(234, 21, 44, 0.1) 100%);
+}
+.scheme_space .btn.disabled.limited.bldlackResConvert.btnInterior:hover {
+	background: no-repeat border-box linear-gradient(90deg, #EA152C 0%, #EA152C 10px, rgba(234, 21, 44, 0.1) 11px, rgba(234, 21, 44, 0.1) 100%);
 }
 .scheme_space .btn:not(.disabled).bldlackResConvert {
 	background: no-repeat border-box linear-gradient(90deg, #EA152C 0%, #EA152C 11px, rgba(18, 231, 209, 0.1) 12px, rgba(18, 231, 209, 0.1) 100%);
 }
+.scheme_space .btn:not(.disabled).bldlackResConvert.btnInterior {
+	background: no-repeat border-box linear-gradient(90deg, #EA152C 0%, #EA152C 10px, rgba(18, 231, 209, 0.1) 11px, rgba(18, 231, 209, 0.1) 100%);
+}
 .scheme_space .btn:not(.disabled).bldlackResConvert:hover {
 	background: no-repeat border-box linear-gradient(90deg, #EA152C 0%, #EA152C 11px, rgba(22, 126, 157, 0.6) 12px, rgba(22, 126, 157, 0.6) 100%);
+}
+.scheme_space .btn:not(.disabled).bldlackResConvert.btnInterior:hover {
+	background: no-repeat border-box linear-gradient(90deg, #EA152C 0%, #EA152C 10px, rgba(22, 126, 157, 0.6) 11px, rgba(22, 126, 157, 0.6) 100%);
 }
 .scheme_space .btn.disabled.bldEnabled {
 	background: no-repeat border-box linear-gradient(90deg, #35C283 0%, #35C283 11px, rgba(140, 140, 140, 0.1) 12px, rgba(140, 140, 140, 0.1) 100%);
 }
+.scheme_space .btn.disabled.bldEnabled.btnInterior {
+	background: no-repeat border-box linear-gradient(90deg, #35C283 0%, #35C283 10px, rgba(140, 140, 140, 0.1) 11px, rgba(140, 140, 140, 0.1) 100%);
+}
 .scheme_space .btn.disabled.bldEnabled:hover {
 	background: no-repeat border-box linear-gradient(90deg, #35C283 0%, #35C283 11px, rgba(255, 255, 255, 0.1) 12px, rgba(255, 255, 255, 0.1) 100%);
+}
+.scheme_space .btn.disabled.bldEnabled.btnInterior:hover {
+	background: no-repeat border-box linear-gradient(90deg, #35C283 0%, #35C283 10px, rgba(255, 255, 255, 0.1) 11px, rgba(255, 255, 255, 0.1) 100%);
 }
 .scheme_space .btn.disabled.limited.bldEnabled {
 	background: no-repeat border-box linear-gradient(90deg, #35C283 0%, #35C283 11px, rgba(146, 0, 23, 0.1) 12px, rgba(146, 0, 23, 0.1) 100%);
 }
+.scheme_space .btn.disabled.limited.bldEnabled.btnInterior {
+	background: no-repeat border-box linear-gradient(90deg, #35C283 0%, #35C283 10px, rgba(146, 0, 23, 0.1) 11px, rgba(146, 0, 23, 0.1) 100%);
+}
 .scheme_space .btn.disabled.limited.bldEnabled:hover {
 	background: no-repeat border-box linear-gradient(90deg, #35C283 0%, #35C283 11px, rgba(234, 21, 44, 0.1) 12px, rgba(234, 21, 44, 0.1) 100%);
+}
+.scheme_space .btn.disabled.limited.bldEnabled.btnInterior:hover {
+	background: no-repeat border-box linear-gradient(90deg, #35C283 0%, #35C283 10px, rgba(234, 21, 44, 0.1) 11px, rgba(234, 21, 44, 0.1) 100%);
 }
 .scheme_space .btn:not(.disabled).bldEnabled {
 	background: no-repeat border-box linear-gradient(90deg, #35C283 0%, #35C283 11px, rgba(18, 231, 209, 0.1) 12px, rgba(18, 231, 209, 0.1) 100%);
 }
+.scheme_space .btn:not(.disabled).bldEnabled.btnInterior {
+	background: no-repeat border-box linear-gradient(90deg, #35C283 0%, #35C283 10px, rgba(18, 231, 209, 0.1) 11px, rgba(18, 231, 209, 0.1) 100%);
+}
 .scheme_space .btn:not(.disabled).bldEnabled:hover {
 	background: no-repeat border-box linear-gradient(90deg, #35C283 0%, #35C283 11px, rgba(22, 126, 157, 0.6) 12px, rgba(22, 126, 157, 0.6) 100%);
+}
+.scheme_space .btn:not(.disabled).bldEnabled.btnInterior:hover {
+	background: no-repeat border-box linear-gradient(90deg, #35C283 0%, #35C283 10px, rgba(22, 126, 157, 0.6) 11px, rgba(22, 126, 157, 0.6) 100%);
 }
 /* *** end of green light for machine on/off *** */
 .scheme_space .dialog { /* window options version credits */

--- a/res/theme_spooky.css
+++ b/res/theme_spooky.css
@@ -145,6 +145,12 @@ body.scheme_spooky.with_background_image {
 .scheme_spooky .modern .btnContent {
     padding: 10px 0 10px 1px; /* 1px left for buttons without power background-image */
 }
+.scheme_spooky .btn.modern.btnInterior {
+	outline: none;
+}
+.scheme_spooky .btn.modern.btnInterior.bldEnabled {
+	border-radius: 3px;
+}
 /* *** green and red light for machine on/off *** */
 .scheme_spooky .btn.bldEnabled div.btnContent,
 .scheme_spooky .btn.bldlackResConvert div.btnContent {

--- a/res/theme_tombstone.css
+++ b/res/theme_tombstone.css
@@ -101,6 +101,9 @@ body.scheme_tombstone {
 .scheme_tombstone .modern .btnContent {
     padding: 10px 0 10px 1px; /* 1px left for buttons without power background-image */
 }
+.scheme_tombstone .btnWrapper {
+	background: transparent !important;
+}
 /* *** green and red light for machine on/off *** */
 .scheme_tombstone .btn.bldEnabled div.btnContent,
 .scheme_tombstone .btn.bldlackResConvert div.btnContent {

--- a/res/theme_unicorn.css
+++ b/res/theme_unicorn.css
@@ -97,6 +97,12 @@ body.scheme_unicorn.with_background_image {
 .scheme_unicorn .modern .btnContent {
     padding: 10px 0 10px 1px; /* 1px left for buttons without power background-image */
 }
+.scheme_unicorn .btnInterior {
+	box-shadow: none m !important;
+}
+.scheme_unicorn .btn.modern.btnInterior.small-text a {
+	margin: -9px 0;
+}
 /* *** green and red light for machine on/off *** */
 .scheme_unicorn .btn.bldEnabled div.btnContent,
 .scheme_unicorn .btn.bldlackResConvert div.btnContent {
@@ -106,26 +112,50 @@ body.scheme_unicorn.with_background_image {
 .scheme_unicorn .btn.disabled.bldlackResConvert { /* color #e43011 */ /* color for lack resources convertion */
 	background: no-repeat border-box linear-gradient(90deg, #e43011 0%, #e43011 11px, #223244 12px, #223244 100%);
 }
+.scheme_unicorn .btn.disabled.bldlackResConvert.btnInterior {
+	background: no-repeat border-box linear-gradient(90deg, #e43011 0%, #e43011 10px, #223244 11px, #223244 100%);
+}
 .scheme_unicorn .btn.disabled.bldlackResConvert:hover {
 	background: no-repeat border-box linear-gradient(90deg, #e43011 0%, #e43011 11px, #223244 12px, #223244 100%);
+}
+.scheme_unicorn .btn.disabled.bldlackResConvert.btnInterior:hover {
+	background: no-repeat border-box linear-gradient(90deg, #e43011 0%, #e43011 10px, #223244 11px, #223244 100%);
 }
 .scheme_unicorn .btn:not(.disabled).bldlackResConvert {
 	background: no-repeat border-box linear-gradient(90deg, #e43011 0%, #e43011 11px, #f0ebe1 12px, #f0ebe1 100%);
 }
+.scheme_unicorn .btn:not(.disabled).bldlackResConvert.btnInterior {
+	background: no-repeat border-box linear-gradient(90deg, #e43011 0%, #e43011 10px, #f0ebe1 11px, #f0ebe1 100%);
+}
 .scheme_unicorn .btn:not(.disabled).bldlackResConvert:hover {
 	background: no-repeat border-box linear-gradient(90deg, #ee4022 0%, #ee4022 11px, #f4f1e9 12px, #f4f1e9 100%);
+}
+.scheme_unicorn .btn:not(.disabled).bldlackResConvert.btnInterior:hover {
+	background: no-repeat border-box linear-gradient(90deg, #ee4022 0%, #ee4022 10px, #f4f1e9 11px, #f4f1e9 100%);
 }
 .scheme_unicorn .btn.disabled.bldEnabled { /* color #7AA738 */
 	background: no-repeat border-box linear-gradient(90deg, #7AA738 0%, #7AA738 11px, #223244 12px, #223244 100%);
 }
+.scheme_unicorn .btn.disabled.bldEnabled.btnInterior {
+	background: no-repeat border-box linear-gradient(90deg, #7AA738 0%, #7AA738 10px, #223244 11px, #223244 100%);
+}
 .scheme_unicorn .btn.disabled.bldEnabled:hover {
 	background: no-repeat border-box linear-gradient(90deg, #7AA738 0%, #5D743A 11px, #223244 12px, #223244 100%);
+}
+.scheme_unicorn .btn.disabled.bldEnabled.btnInterior:hover {
+	background: no-repeat border-box linear-gradient(90deg, #7AA738 0%, #5D743A 10px, #223244 11px, #223244 100%);
 }
 .scheme_unicorn .btn:not(.disabled).bldEnabled {
 	background: no-repeat border-box linear-gradient(90deg, #7AA738 0%, #7AA738 11px, #f0ebe1 12px, #f0ebe1 100%);
 }
+.scheme_unicorn .btn:not(.disabled).bldEnabled.btnInterior {
+	background: no-repeat border-box linear-gradient(90deg, #7AA738 0%, #7AA738 10px, #f0ebe1 11px, #f0ebe1 100%);
+}
 .scheme_unicorn .btn:not(.disabled).bldEnabled:hover {
 	background: no-repeat border-box linear-gradient(90deg, #94dc23 0%, #94dc23 11px, #f4f1e9 12px, #f4f1e9 100%);
+}
+.scheme_unicorn .btn:not(.disabled).bldEnabled.btnInterior:hover {
+	background: no-repeat border-box linear-gradient(90deg, #94dc23 0%, #94dc23 10px, #f4f1e9 11px, #f4f1e9 100%);
 }
 /* *** end of green light for machine on/off *** */
 .scheme_unicorn .dialog {

--- a/res/theme_vessel.css
+++ b/res/theme_vessel.css
@@ -54,7 +54,7 @@ body.scheme_vessel {
 	background-color: rgba(0, 0, 0, 0.3);
 	border: solid 1px rgba(0, 0, 0, 0.5);
 	box-shadow: 1px 1px 3px #000000 inset,
-                 0 1px 0 rgba(204, 204, 204, 0.2) !important; /* color #CCCCCC */
+                 0 1px 0 rgba(204, 204, 204, 0.15) !important; /* color #CCCCCC */
 }
 .scheme_vessel .btn.modern.disabled:hover {
 	background-color: rgba(0, 0, 0, 0.85);
@@ -117,11 +117,29 @@ body.scheme_vessel {
 	/* 10px left not necessary for buttons without on/off */
 	padding: 10px 0 10px 1px; /* 1px left for buttons without power background-image */
 }
+.scheme_vessel .btn.small-text span,
+.scheme_vessel .btn.small-text a {
+    font-size: 92.6%;
+}
+.scheme_vessel .btn.modern.btnWrapper {
+	box-shadow: 1px 1px 3px #000000 inset, 0 1px 0 rgba(204, 204, 204, 0.15);
+	background: transparent;
+	background-color: transparent !important;
+}
+.scheme_vessel .btn.modern.btnInterior {
+	border-radius: 5px;
+}
+.scheme_vessel .btn.modern.btnInterior.small-text:not(.bldEnabled) .btnContent {
+	padding: 9px 0 10px 1px;
+}
+.scheme_vessel .btn.modern.btnInterior.small-text a {
+	margin: -9px 0;
+}
 /*** green and red light for machine on/off ***/
 .scheme_vessel .btn.bldEnabled div.btnContent,
 .scheme_vessel .btn.bldlackResConvert div.btnContent {
 	border: none; /* also allows you to remove the height difference with the other buttons (they have no border on div.content) */
-	padding: 10px 0 10px 18px; /* 18px left for power background-image - default padding: 10px 0 10px 10px; */
+	padding: 9px 0 10px 18px; /* 18px left for power background-image - default padding: 10px 0 10px 10px; */
 }
 .scheme_vessel .btn.bldlackResConvert div.btnContent {
 	background: no-repeat local left 3px center url('img/theme_vessel_battery_empty.png'); /* source of images for graphic design : https://pngtree.com/ Volkeyrn: permanent premium member */

--- a/res/theme_vintage.css
+++ b/res/theme_vintage.css
@@ -112,6 +112,9 @@ body.scheme_vintage {
 .scheme_vintage .modern .btnContent {
     padding: 10px 0 10px 1px; /* 1px left for buttons without power background-image */
 }
+.scheme_vintage .btn.modern.btnInterior.disabled:hover {
+	box-shadow: none;
+}
 /*** green and red light for machine on/off ***/
 .scheme_vintage .btn.bldEnabled div.btnContent,
 .scheme_vintage .btn.bldlackResConvert div.btnContent {
@@ -121,26 +124,50 @@ body.scheme_vintage {
 .scheme_vintage .btn.disabled.bldlackResConvert { /* color for lack resources convertion */
 	background: no-repeat border-box linear-gradient(90deg, #cd564f 0%, #cd564f 12px, #161619 15px, #161619 100%);
 }
+.scheme_vintage .btn.disabled.bldlackResConvert.btnInterior {
+	background: no-repeat border-box linear-gradient(90deg, #cd564f 0%, #cd564f 11px, #161619 14px, #161619 100%);
+}
 .scheme_vintage .btn.disabled.bldlackResConvert:hover {
 	background: no-repeat border-box linear-gradient(90deg, #cd564f 0%, #cd564f 12px, #161619 15px, #161619 100%);
+}
+.scheme_vintage .btn.disabled.bldlackResConvert.btnInterior:hover {
+	background: no-repeat border-box linear-gradient(90deg, #cd564f 0%, #cd564f 11px, #161619 14px, #161619 100%);
 }
 .scheme_vintage .btn:not(.disabled).bldlackResConvert {
 	background: no-repeat border-box linear-gradient(90deg, #cd564f 0%, #cd564f 12px, #403e49 15px, #403e49 100%);
 }
+.scheme_vintage .btn:not(.disabled).bldlackResConvert.btnInterior {
+	background: no-repeat border-box linear-gradient(90deg, #cd564f 0%, #cd564f 11px, #403e49 14px, #403e49 100%);
+}
 .scheme_vintage .btn:not(.disabled).bldlackResConvert:hover {
 	background: no-repeat border-box linear-gradient(90deg, #B53B34 0%, #cd564f 12px, #d4b258 15px, #d4b258 100%);
+}
+.scheme_vintage .btn:not(.disabled).bldlackResConvert.btnInterior:hover {
+	background: no-repeat border-box linear-gradient(90deg, #B53B34 0%, #cd564f 11px, #d4b258 14px, #d4b258 100%);
 }
 .scheme_vintage .btn.disabled.bldEnabled {
 	background: no-repeat border-box linear-gradient(90deg, #709c85 0%, #709c85 12px, #161619 15px, #161619 100%);
 }
+.scheme_vintage .btn.disabled.bldEnabled.btnInterior {
+	background: no-repeat border-box linear-gradient(90deg, #709c85 0%, #709c85 11px, #161619 14px, #161619 100%);
+}
 .scheme_vintage .btn.disabled.bldEnabled:hover {
 	background: no-repeat border-box linear-gradient(90deg, #709c85 0%, #709c85 12px, #161619 15px, #161619 100%);
+}
+.scheme_vintage .btn.disabled.bldEnabled.btnInterior:hover {
+	background: no-repeat border-box linear-gradient(90deg, #709c85 0%, #709c85 11px, #161619 14px, #161619 100%);
 }
 .scheme_vintage .btn:not(.disabled).bldEnabled {
 	background: no-repeat border-box linear-gradient(90deg, #709c85 0%, #709c85 12px, #403e49 15px, #403e49 100%);
 }
+.scheme_vintage .btn:not(.disabled).bldEnabled.btnInterior {
+	background: no-repeat border-box linear-gradient(90deg, #709c85 0%, #709c85 11px, #403e49 14px, #403e49 100%);
+}
 .scheme_vintage .btn:not(.disabled).bldEnabled:hover {
 	background: no-repeat border-box linear-gradient(90deg, #1b786d 0%, #709c85 12px, #d4b258 15px, #d4b258 100%);
+}
+.scheme_vintage .btn:not(.disabled).bldEnabled.btnInterior:hover {
+	background: no-repeat border-box linear-gradient(90deg, #1b786d 0%, #709c85 11px, #d4b258 14px, #d4b258 100%);
 }
 /*** end of green light for machine on/off ***/
 .scheme_vintage .dialog {

--- a/res/theme_wood.css
+++ b/res/theme_wood.css
@@ -127,11 +127,15 @@ body.scheme_wood.with_background_image {
 .scheme_wood h1:first-child {
     margin-top: 0;
 }
-/* .scheme_wood .btn.modern.small-text { */
-	/* default font-size: 90%; */
-/* } */
 .scheme_wood .modern .btnContent {
     padding: 10px 0 10px 1px; /* 1px left for buttons without power background-image */
+}
+.scheme_wood .btn.modern.btnInterior,
+.scheme_wood .btn.modern.btnInterior:hover {
+	box-shadow: none;
+}
+.scheme_wood .btn.modern.btnInterior.small-text a {
+	margin: -9px 0;
 }
 /*** green and red light for machine on/off ***/
 .scheme_wood .btn.bldEnabled div.btnContent,
@@ -143,32 +147,64 @@ body.scheme_wood.with_background_image {
 	background: no-repeat border-box linear-gradient(90deg, #a7372c 0%, rgba(167, 55, 44, 0.5) 7px, transparent 15px, transparent 100%),
 		local no-repeat bottom -86px right -30px url('img/theme_wood_background_02.jpg');
 }
+.scheme_wood .btn.disabled.bldlackResConvert.btnInterior {
+	background: no-repeat border-box linear-gradient(90deg, #a7372c 0%, rgba(167, 55, 44, 0.5) 6px, transparent 14px, transparent 100%),
+		local no-repeat bottom -86px right -30px url('img/theme_wood_background_02.jpg');
+}
 .scheme_wood .btn.disabled.bldlackResConvert:hover {
 	background: no-repeat border-box linear-gradient(90deg, #a7372c 0%, rgba(167, 55, 44, 0.5) 7px, transparent 15px, transparent 100%),
+		local no-repeat bottom -86px right -30px url('img/theme_wood_background_02.jpg');
+}
+.scheme_wood .btn.disabled.bldlackResConvert.btnInterior:hover {
+	background: no-repeat border-box linear-gradient(90deg, #a7372c 0%, rgba(167, 55, 44, 0.5) 6px, transparent 14px, transparent 100%),
 		local no-repeat bottom -86px right -30px url('img/theme_wood_background_02.jpg');
 }
 .scheme_wood .btn:not(.disabled).bldlackResConvert {
 	background: no-repeat border-box linear-gradient(90deg, #a7372c 0%, rgba(167, 55, 44, 0.5) 7px, transparent 15px, transparent 100%),
 		local no-repeat bottom -62px right url('img/theme_wood_background_01.jpg');
 }
+.scheme_wood .btn:not(.disabled).bldlackResConvert.btnInterior {
+	background: no-repeat border-box linear-gradient(90deg, #a7372c 0%, rgba(167, 55, 44, 0.5) 6px, transparent 14px, transparent 100%),
+		local no-repeat bottom -62px right url('img/theme_wood_background_01.jpg');
+}
 .scheme_wood .btn:not(.disabled).bldlackResConvert:hover {
 	background: no-repeat border-box linear-gradient(90deg, #a7372c 0%, rgba(167, 55, 44, 0.5) 7px, transparent 15px, transparent 100%),
+		local no-repeat bottom -62px right -10px url('img/theme_wood_background_01.jpg');
+}
+.scheme_wood .btn:not(.disabled).bldlackResConvert.btnInterior:hover {
+	background: no-repeat border-box linear-gradient(90deg, #a7372c 0%, rgba(167, 55, 44, 0.5) 6px, transparent 14px, transparent 100%),
 		local no-repeat bottom -62px right -10px url('img/theme_wood_background_01.jpg');
 }
 .scheme_wood .btn.disabled.bldEnabled {
 	background: no-repeat border-box linear-gradient(90deg, #9e9527 0%, rgba(158, 149, 39, 0.5) 7px, transparent 15px, transparent 100%),
 		local no-repeat bottom -86px right -30px url('img/theme_wood_background_02.jpg');
 }
+.scheme_wood .btn.disabled.bldEnabled.btnInterior {
+	background: no-repeat border-box linear-gradient(90deg, #9e9527 0%, rgba(158, 149, 39, 0.5) 6px, transparent 14px, transparent 100%),
+		local no-repeat bottom -86px right -30px url('img/theme_wood_background_02.jpg');
+}
 .scheme_wood .btn.disabled.bldEnabled:hover {
 	background: no-repeat border-box linear-gradient(90deg, #9e9527 0%, rgba(158, 149, 39, 0.5) 7px, transparent 15px, transparent 100%),
+		local no-repeat bottom -86px right -30px url('img/theme_wood_background_02.jpg');
+}
+.scheme_wood .btn.disabled.bldEnabled.btnInterior:hover {
+	background: no-repeat border-box linear-gradient(90deg, #9e9527 0%, rgba(158, 149, 39, 0.5) 6px, transparent 14px, transparent 100%),
 		local no-repeat bottom -86px right -30px url('img/theme_wood_background_02.jpg');
 }
 .scheme_wood .btn:not(.disabled).bldEnabled {
 	background: no-repeat border-box linear-gradient(90deg, #9e9527 0%, rgba(158, 149, 39, 0.5) 7px, transparent 15px, transparent 100%),
 		local no-repeat bottom -62px right url('img/theme_wood_background_01.jpg');
 }
+.scheme_wood .btn:not(.disabled).bldEnabled.btnInterior {
+	background: no-repeat border-box linear-gradient(90deg, #9e9527 0%, rgba(158, 149, 39, 0.5) 6px, transparent 14px, transparent 100%),
+		local no-repeat bottom -62px right url('img/theme_wood_background_01.jpg');
+}
 .scheme_wood .btn:not(.disabled).bldEnabled:hover {
 	background: no-repeat border-box linear-gradient(90deg, #b6b042 0%, rgba(182, 176, 66, 0.5) 7px, transparent 15px, transparent 100%),
+		local no-repeat bottom -62px right -10px url('img/theme_wood_background_01.jpg');
+}
+.scheme_wood .btn:not(.disabled).bldEnabled.btnInterior:hover {
+	background: no-repeat border-box linear-gradient(90deg, #b6b042 0%, rgba(182, 176, 66, 0.5) 6px, transparent 14px, transparent 100%),
 		local no-repeat bottom -62px right -10px url('img/theme_wood_background_01.jpg');
 }
 /*** end of green light for machine on/off ***/


### PR DESCRIPTION
clickable button borders can be an issue when clicking on a sub-button. for example, if you try to shatter 500 years but accidentally click on the border around it, it will only shatter one year.

this is remedied by removing the border, and wrapping the button in a click-through div with its own border.

unfortunately, this makes the button element smaller and throws the ui slightly off, hence all the theme adjustments. i did my best to preserve the appearance of all themes. some (particularly those with box shadows) are not pixel-perfect, but they should be similar enough for the differences to be unnoticeable without a careful side-by-side comparison.

in rare instances, there were noticeable font size differences between small-text buttons in the bonfire tab and other buttons due to core.js incorrectly applying a 90% font size to some buttons on update, instead of correctly using the small-text class as it does on render. my change makes them more consistent by necessity, which i believe is a positive change, and is the only case where i did not try to faithfully preserve the original theme appearance. for an example, compare the bonfire and time tabs in the gold theme.