### PR TITLE
Siphoning Update Bugfixes & UI Stuff

### DIFF
--- a/game.js
+++ b/game.js
@@ -2556,10 +2556,12 @@ dojo.declare("com.nuclearunicorn.game.ui.GamePage", null, {
 				this.telemetry.load(saveData);
 				this.ui.renderFilters();
 
-                for (var i in this.managers){
+				for (var i in this.managers) {
 					console.log("game#load - Processing", this.managers[i].id, "...");
-                    this.managers[i].load(saveData);
+					this.managers[i].load(saveData);
 				}
+				//Ensure Cryptotheology-based unlock conditions for various things work properly:
+				this.religion.afterLoad(); //Kind of unelegant, but it works
 				
 				this._publish("server/load", saveData);
 			}

--- a/js/jsx/queue.jsx.js
+++ b/js/jsx/queue.jsx.js
@@ -229,7 +229,7 @@ WQueue = React.createClass({
                             options[indexToUse].name,
                             self.state.typeId,
                             options[indexToUse].label,
-                            e.shiftKey
+                            e
                         );
                     }
 

--- a/js/religion.js
+++ b/js/religion.js
@@ -125,7 +125,14 @@ dojo.declare("classes.managers.ReligionManager", com.nuclearunicorn.core.TabMana
 		this.loadMetadata(this.religionUpgrades, _data.ru);
 		this.loadMetadata(this.transcendenceUpgrades, _data.tu);
 		this.loadMetadata(this.pactsManager.pacts, _data.pact);
-
+	},
+	/**
+	 * This function is meant to be called while loading a savefile, AFTER everything has been initialized.
+	 * In here, we handle matters which require communication with other systems of the game.
+	 * For example: Properly unlock different game features based on permanent religion upgrades
+	 */
+	afterLoad: function() {
+		//Cryptotheology-based unlock conditions
 		for (var i = 0; i < this.transcendenceUpgrades.length; i++){
 			var tu = this.transcendenceUpgrades[i];
 			if (this.transcendenceTier >= tu.tier && (!tu.evaluateLocks || tu.evaluateLocks(this.game))) {

--- a/js/religion.js
+++ b/js/religion.js
@@ -619,7 +619,7 @@ dojo.declare("classes.managers.ReligionManager", com.nuclearunicorn.core.TabMana
 						faithMax = 3000;
 					}
 				}
-				self.effects["faithMax"] = faithMax;
+				self.effects["faithMax"] = faithMax * 2 /*subject to balance changes*/;
 			}
 		},
 		unlocked: true,

--- a/js/religion.js
+++ b/js/religion.js
@@ -1958,12 +1958,6 @@ dojo.declare("classes.ui.religion.TransformBtnController", com.nuclearunicorn.ga
 			callback(false /*itemBought*/, { reason: "cannot-afford" });
 			return;
 		}
-		if (!model.enabled) {
-			//As far as I can tell, this shouldn't ever happen because being
-			//unable to afford it is the only reason for it to be disabled.
-			callback(false /*itemBought*/, { reason: "not-enabled" });
-			return;
-		}
 		var didWeSucceed = this._transform(model, amt);
 		if (didWeSucceed) {
 			callback(true /*itemBought*/, { reason: "paid-for" });

--- a/js/science.js
+++ b/js/science.js
@@ -2483,10 +2483,19 @@ dojo.declare("classes.ui.PolicyBtnController", com.nuclearunicorn.game.ui.Buildi
 		}
 	},
 
-	//Returns an object with one field:
-	//	reason:		String.  If we can't buy it, why not?  If we can buy it, returns
-	//				"paid-for" regardless of whether we can actually afford it or not.
-	shouldBeBought: function(model, game){ //fail checks:
+	/**
+	 * This function is to be called when the player (or the queue) tries to buy a policy.
+	 * Determines if a policy has a specific reason why the player cannot buy it at the current time.
+	 * @param model   object   The model representing the policy
+	 * @param game    object   The game object
+	 * @param skipConfirmation   boolean   If true, policies will be bought without asking the player "are you sure?"
+	 * 			If true, this overrides game.opts.noConfirm.
+	 * 			If false, respects game.opts.noConfirm.
+	 * @return An object with one field:
+	 * 	reason	string	If we can't buy it, why not?  If we can buy it, returns
+	 *	      	      	"paid-for" regardless of whether we can actually afford it or not.
+	 */
+	shouldBeBought: function(model, game, skipConfirmation) { //fail checks:
 		if (this.game.village.leader && model.metadata.requiredLeaderJob && this.game.village.leader.job != model.metadata.requiredLeaderJob){
 			var jobTitle = this.game.village.getJob(model.metadata.requiredLeaderJob).title;
 			this.game.msg($I("msg.policy.wrongLeaderJobForResearch", [model.metadata.label, jobTitle]), "important");
@@ -2511,7 +2520,7 @@ dojo.declare("classes.ui.PolicyBtnController", com.nuclearunicorn.game.ui.Buildi
 					return { reason: "blocked" };
                 }
 			}
-			if (game.opts.noConfirm){
+			if (game.opts.noConfirm || skipConfirmation) {
 				return { reason: "paid-for" };
 			}
 			return { reason: "require-confirmation" };
@@ -2533,7 +2542,7 @@ dojo.declare("classes.ui.PolicyBtnController", com.nuclearunicorn.game.ui.Buildi
 				reason: "cannot-afford"
 			};
 		}
-		var extendedInfo = this.shouldBeBought(model, this.game);
+		var extendedInfo = this.shouldBeBought(model, this.game, event && event.boughtByQueue /*skipConfirmation*/);
 		
 		if (extendedInfo.reason == 'require-confirmation'){
 			var def = new dojo.Deferred();

--- a/js/science.js
+++ b/js/science.js
@@ -2160,6 +2160,14 @@ dojo.declare("classes.managers.ScienceManager", com.nuclearunicorn.core.TabManag
 					this.description += "<br><span class=\"genericWarning\">" + $I("policy.upfrontPayment.warning") + "</span>";
 				}
 			}
+
+			if (!self.upgrades) { //This will happen only once.
+				//Set upgrades table to include ALL Pacts in the game.
+				//This way, it'll automatically include new Pacts added by any future updates!
+				self.upgrades = { pacts: game.religion.pactsManager.pacts.map(
+					function(pactMeta) {return pactMeta.name;}
+				)};
+			}
 		},
 		evaluateLocks: function(game) {
 			return game.getFeatureFlag("MAUSOLEUM_PACTS") && game.religion.getTU("mausoleum").val && game.religion.getZU("marker").val;
@@ -2172,6 +2180,7 @@ dojo.declare("classes.managers.ScienceManager", com.nuclearunicorn.core.TabManag
 				game.msg($I("policy.upfrontPayment.payment.complete", [requiredPayment]));
 			}
 		},
+		upgrades: null, //To be initialized later
 		unlocked: false,
 		blocked: false,
 		blocks:["siphoning", "feedingFrenzy"]

--- a/js/time.js
+++ b/js/time.js
@@ -2647,7 +2647,7 @@ dojo.declare("classes.queue.manager", null,{
             return;
         }
 
-        var result = controllerAndModel.controller.buyItem(controllerAndModel.model, null);
+        var result = controllerAndModel.controller.buyItem(controllerAndModel.model, { boughtByQueue: true });
         var wasItemBought = result.itemBought;
         var resultOfBuyingItem = {reason: result.reason};
 

--- a/js/time.js
+++ b/js/time.js
@@ -2168,7 +2168,7 @@ dojo.declare("classes.queue.manager", null,{
         return length;
     },
 
-    addToQueue: function(name, type, label, shiftKey /*add all*/){
+    addToQueue: function(name, type, label, event /*optional parameter*/){
         if (!name || !type){
             console.error("queueMgr#addToQueue: unable to add item:", name, type, label);
             return;
@@ -2178,20 +2178,31 @@ dojo.declare("classes.queue.manager", null,{
             return;
         }
 
+        //SHIFT is used throughout the game for "buy all"; CTRL is used for "buy one batch"
+        //The batch size is configurable in the game settings menu (10 by default)
+		if (!event) { event = {}; }
+        var batchSize = this.game.opts.batchSize || 10;
+        var amtToQueue = event.shiftKey ? Infinity : (event.ctrlKey || event.metaKey ? batchSize : 1);
+
+        //Don't ever queue a non-stackable item in bulk--there's no point!
+        if (this.queueNonStackable.includes(type)) {
+            amtToQueue = 1;
+        }
+
+        //Don't add more than can fit inside the queue cap:
+        amtToQueue = Math.min(this.cap - this.queueLength(), amtToQueue);
+        if (amtToQueue < 1) {
+            return; //Already finished queueing
+        }
+
         //TODO: too complex logic, can we streamline it somehow?
         var lastItem = this.queueItems[this.queueItems.length - 1];
         if (this.queueItems.length > 0 && lastItem && lastItem.name == name){
             if (this.queueNonStackable.includes(type)){
                 return;
             }
-            var valOfItem = (lastItem.value || 1) + 1;
+            var valOfItem = (lastItem.value || 1) + amtToQueue;
             lastItem.value = valOfItem;
-
-            if (shiftKey){
-                while (this.queueLength() < this.cap){
-                    this.addToQueue(name, type, label, false);
-                }
-            }
             return;
         }
         
@@ -2203,14 +2214,8 @@ dojo.declare("classes.queue.manager", null,{
             name: name,
             type: type,
             label: label,
-            value: 1    //always store size of the queue group, even if it is a single item
+            value: amtToQueue //always store size of the queue group, even if it is a single item
         });
-
-        if (shiftKey && !this.queueNonStackable.includes(type)){
-            while (this.queueLength() < this.cap){
-                this.addToQueue(name, type, label, false);
-            }
-        }
     },
 
     /**

--- a/js/ui.js
+++ b/js/ui.js
@@ -937,7 +937,7 @@ dojo.declare("classes.ui.DesktopUI", classes.ui.UISystem, {
             $("#queueLink").text($I("ui.queue.link"));
         }
         $("#clearLogHref").text($I("ui.clear.log"));
-        $("#logFiltersBlockText").html($I("ui.log.filters.block"));
+        $("#logFiltersBlockText").html("[<span id=\"filterIcon\">+</span>] " + $I("ui.log.filters.block")); //We don't want to have <span> tags inside the i18n text, so we'll move it here instead.
         $("#pauseBtn").text($I("ui.pause"));
         $("#pauseBtn").attr("title", $I("ui.pause.title"));
         $("#undoBtn").attr("title", $I("ui.undo.title"));

--- a/js/village.js
+++ b/js/village.js
@@ -3853,61 +3853,62 @@ dojo.declare("com.nuclearunicorn.game.ui.JobButtonController", com.nuclearunicor
 	fetchModel: function(options){
 		var model = this.inherited(arguments);
 		var self = this;
-		model.unassignLinks = [
-		  {
-				id: "unassign",
-				title: "[&ndash;]",
-				alt: "minus",
-				handler: function(){
-					self.unassignJobs(model, 1);
-				}
-		   },{
-				id: "unassign5",
-				title: "[-5]",
-				handler: function(){
-					self.unassignJobs(model, 5);
-				}
-		   },{
-				id: "unassign25",
-				title: "[-25]",
-				handler: function(){
-					self.unassignJobs(model, 25);
-				}
-		   },{
-				id: "unassignAll",
-				title: $I("btn.all.unassign"),
-				handler: function(){
-					self.unassignAllJobs(model);
-				}
-		   }];
+		//We will generate links for assigning/unassigning this many kittens:
+		var LINK_AMOUNTS = [5, 25, 100];
 
-		model.assignLinks = [
-			{
-				id: "assign",
-				title: "[+]",
-				alt: "plus",
-				handler: function(){
-					self.assignJobs(model, 1);
+		//Links for +/- 1
+		model.unassignLinks = [{
+			id: "unassign",
+			title: "[&ndash;]",
+			alt: "minus",
+			handler: function() {
+				self.unassignJobs(model, 1);
+			}
+		}];
+		model.assignLinks = [{
+			id: "assign",
+			title: "[+]",
+			alt: "plus",
+			handler: function() {
+				self.assignJobs(model, 1);
+			}
+		}];
+		//Links for +/- amt, where amt is specified in LINK_AMOUNTS
+		//(Generate only if we have at least 2x as many kittens as amt.)
+		LINK_AMOUNTS.forEach(function(amt) {
+			if (this.game.village.getKittens() < amt * 2) {
+				return; //Skip generating links for this amt
+			}
+			model.unassignLinks.push({
+				id: "unassign" + amt,
+				title: "[-" + amt + "]",
+				handler: function() {
+					self.unassignJobs(model, amt);
 				}
-		   },{
-				id: "assign5",
-				title: "[+5]",
+			});
+			model.assignLinks.push({
+				id: "assign" + amt,
+				title: "[+" + amt + "]",
 				handler: function(){
-					self.assignJobs(model, 5);
+					self.assignJobs(model, amt);
 				}
-		   },{
-				id: "assign25",
-				title: "[+25]",
-				handler: function(){
-					self.assignJobs(model, 25);
-				}
-		   },{
-				id: "assignall",
-				title: $I("btn.all.assign"),
-				handler: function(){
-					self.assignAllJobs(model);
-				}
-		   }];
+			});
+		});
+		//Links for +/- ALL
+		model.unassignLinks.push({
+			id: "unassignAll",
+			title: $I("btn.all.unassign"),
+			handler: function() {
+				self.unassignAllJobs(model);
+			}
+		});
+		model.assignLinks.push({
+			id: "assignall",
+			title: $I("btn.all.assign"),
+			handler: function() {
+				self.assignAllJobs(model);
+			}
+		});
 		return model;
 	},
 

--- a/js/village.js
+++ b/js/village.js
@@ -3879,6 +3879,9 @@ dojo.declare("com.nuclearunicorn.game.ui.JobButtonController", com.nuclearunicor
 			if (this.game.village.getKittens() < amt * 2) {
 				return; //Skip generating links for this amt
 			}
+			if (this.game.village.getJobLimit(model.job.name) < amt) {
+				return; //Doesn't make sense to assign +/- N to a job if the max is less than that...
+			}
 			model.unassignLinks.push({
 				id: "unassign" + amt,
 				title: "[-" + amt + "]",

--- a/js/workshop.js
+++ b/js/workshop.js
@@ -2955,90 +2955,49 @@ dojo.declare("com.nuclearunicorn.game.ui.CraftButtonController", com.nuclearunic
 		var model = this.inherited(arguments);
 		var self = this;
 		if (this.game.science.get("mechanization").researched) {
-			if (!this.controllerOpts.compactStyle) {
-				model.unassignCraftLinks = [
-				  {
-						id: "unassign",
-						title: "[-]",
-						handler: function(){
-							self.unassignCraftJob(model, 1);
-						},
-					  	enabled: true
-				   },{
-						id: "unassign5",
-						title: "[-5]",
-						handler: function(){
-							self.unassignCraftJob(model, 5);
-						},
-						enabled: true
-				   },{
-						id: "unassign25",
-						title: "[-25]",
-						handler: function(){
-							self.unassignCraftJob(model, 25);
-						},
-						enabled: true
-				   }];
+			//We will generate links for assigning/unassigning this many engineers:
+			var LINK_AMOUNTS = [5, 25, 100];
 
-				model.assignCraftLinks = [
-					{
-						id: "assign",
-						title: "[+]",
-						handler: function(){
-							self.assignCraftJob(model, 1);
-						},
-						enabled: true
-				   },{
-						id: "assign5",
-						title: "[+5]",
-						handler: function(){
-							self.assignCraftJob(model, 5);
-						},
-						enabled: true
-				   },{
-						id: "assign25",
-						title: "[+25]",
-						handler: function(){
-							self.assignCraftJob(model, 25);
-						},
-						enabled: true
-				   }];
-			} else {
-				model.unassignCraftLinks = [
-				  {
-						id: "unassign",
-						title: "-",
-						handler: function(){
-							self.unassignCraftJob(model, 1);
-						},
-					  	enabled: true
-				   },{
-						id: "unassign25",
-						title: "-25",
-						handler: function(){
-							self.unassignCraftJob(model, 25);
-						},
-						enabled: true
-				   }];
-
-				model.assignCraftLinks = [
-					{
-						id: "assign",
-						title: "+",
-						handler: function(){
-							self.assignCraftJob(model, 1);
-						},
-						enabled: true
-				   },{
-						id: "assign25",
-						title: "+25",
-						handler: function(){
-							self.assignCraftJob(model, 25);
-						},
-						enabled: true
-				   }];
-			}
-
+			//Links for +/- 1
+			model.unassignCraftLinks = [{
+				id: "unassign",
+				title: "[-]",
+				handler: function(){
+					self.unassignCraftJob(model, 1);
+				},
+				enabled: true
+			}];
+			model.assignCraftLinks = [{
+				id: "assign",
+				title: "[+]",
+				handler: function(){
+					self.assignCraftJob(model, 1);
+				},
+				enabled: true
+			}];
+			//Links for +/- amt, where amt is specified in LINK_AMOUNTS
+			//(Generate only if we have at least as many engineers as amt.)
+			LINK_AMOUNTS.forEach(function(amt) {
+				if (this.game.village.getWorkerKittens("engineer") < amt) {
+					return; //Skip generating links for this amt
+				}
+				model.unassignCraftLinks.push({
+					id: "unassign" + amt,
+					title: "[-" + amt + "]",
+					handler: function() {
+						self.unassignCraftJob(model, amt);
+					},
+					enabled: true
+				});
+				model.assignCraftLinks.push({
+					id: "assign" + amt,
+					title: "[+" + amt + "]",
+					handler: function(){
+						self.assignCraftJob(model, amt);
+					},
+					enabled: true
+				});
+			});
 		} else {
 			model.assignCraftLinks = [];
 			model.unassignCraftLinks = [];

--- a/res/default.css
+++ b/res/default.css
@@ -266,6 +266,7 @@ select>option {
 
 .dropdown-link {
     cursor: pointer;
+    white-space: nowrap !important;
 }
 
 .spacer {

--- a/test/game.test.js
+++ b/test/game.test.js
@@ -570,7 +570,7 @@ test("Queue should correctly add and remove items", () => {
      */
 
     //test shift key option
-    queue.addToQueue("field", "buildings", "N/A", true /*all available*/);
+    queue.addToQueue("field", "buildings", "N/A", { shiftKey: true } /*all available*/);
     expect(queue.queueLength()).toBe(13);
     expect(queue.queueItems.length).toBe(2);
 


### PR DESCRIPTION
### Balancing
- Double the max faith reward from Unicorn Tears.
### Bugfixes
- Fix error that appears when toggling the “log filters” menu in English language.  (As a consequence of the fix, if playing on any language other than English, there will be a duplicate [+] or [-] before the log filters until the translations get updated.)
- Fix a bug where when you purchase Upfront Payment, it doesn’t immediately update the upkeep costs of all your existing Pacts.
- Fix the bug where the 20%/50%/all links on the “Sacrifice Unicorns” button would intermittently not work.  (It turns out this one was my fault.  Sorry, folks.)
- Fixed the bug where if you had unlocked Temporal Presses using Blazars, but the unlock didn’t trigger properly, the problem would persist even when reloading the game.  Now, reloading the game WILL fix the problem.
### UI Stuff
- When the queue tries to build a policy, it’ll just **work**.  It won’t ask the player to confirm.
- Add a +100/-100 button for assigning jobs.  The +/- 5, 25, and 100 buttons for assigning jobs only appear if you have at least 2 times as many kittens as the value listed.
- Add a +100/-100 button for assigning engineers.  The +/- 5, 25, and 100 buttons only appear once the player has that many engineers
- Add CTRL + click support for “add to queue” button.
- Add CTRL + click & SHIFT + click support for the “send hunters” button.
- The “send hunters” button now has links for 20%, 50%, all, similar to the trade buttons.
Internal Stuff
- The API for adding things to the queue has been changed.  I don't know if any external scripts rely on it, but I figured I should announce it anyways.