### PR TITLE
Fix Pact of Chronicler effect not immidietly working on Temporal Impendence

### DIFF
--- a/js/religion.js
+++ b/js/religion.js
@@ -929,7 +929,8 @@ dojo.declare("classes.managers.ReligionManager", com.nuclearunicorn.core.TabMana
 			"timeRatio"
 		],
 		upgrades: {
-			spaceBuilding: ["spaceBeacon"]
+			spaceBuilding: ["spaceBeacon"],
+			chronoforge: ["temporalImpedance"]
 		},
 		calculateEffects: function(self, game) {
 			self.togglable = false;


### PR DESCRIPTION
Due to order of events, BlackPyramid needs to update temporalImpendance after it itself has obtained the relevant effects. Still a one line fix, just not the line I initially thought