### PR TITLE
fix bloodstone hunting bugs

### DIFF
--- a/js/math.js
+++ b/js/math.js
@@ -85,5 +85,12 @@ dojo.declare("com.nuclearunicorn.game.Math", null, {
         	result += coefficients[i];
         }
         return result;
+    },
+
+    // the geometric distribution is how many attempts are needed until an event of probability p occurs
+    geometricRandom: function(p) {
+        var u = 0;
+        while (u === 0) {u = Math.random();} //Converting [0,1) to (0,1)
+        return Math.ceil(Math.log(u) / this.log1p(-p));
     }
 });

--- a/js/math.js
+++ b/js/math.js
@@ -89,6 +89,14 @@ dojo.declare("com.nuclearunicorn.game.Math", null, {
 
     // the geometric distribution is how many attempts are needed until an event of probability p occurs
     geometricRandom: function(p) {
+        // normalize p to the range (0,1)
+        if (p >= 1) { return 1; }
+        if (p <= 0) {
+            // event is impossible, so an "infinite number" of tries is needed.
+            // returning infinity here instead of throwing an error makes code like
+            // "N = Math.max(N - geometricRandom(p), 0)" work correctly automatically
+            return Infinity;
+        }
         var u = 0;
         while (u === 0) {u = Math.random();} //Converting [0,1) to (0,1)
         return Math.ceil(Math.log(u) / this.log1p(-p));

--- a/js/village.js
+++ b/js/village.js
@@ -885,9 +885,20 @@ dojo.declare("classes.managers.VillageManager", com.nuclearunicorn.core.TabManag
 
 		if (this.game.resPool.get("zebras").value >= 10) {
 			var bloodstoneRatio = 1 + this.game.getEffect("bloodstoneRatio");
-			var bloodstone = this.game.resPool.addResEvent("bloodstone", this.game.math.binominalRandomInteger(squads, (this.game.resPool.get("bloodstone").value == 0 ? 0.05 : 0.0005) * bloodstoneRatio));
-			if (bloodstone > 0 && this.game.resPool.get("bloodstone").value == 1) {
-				this.game.msg($I("village.new.bloodstone"), "important", "ironWill");
+			var bloodstoneSquads = squads;
+			if (this.game.resPool.get("bloodstone").value == 0) {
+				// the first bloodstone has a 5% chance, further ones are much rarer
+				var huntsUntilBloodstone = this.game.math.geometricRandom(0.05 * bloodstoneRatio);
+				if (huntsUntilBloodstone <= bloodstoneSquads) {
+					this.game.resPool.addResEvent("bloodstone", 1);
+					this.game.msg($I("village.new.bloodstone"), "important", "ironWill");
+				}
+				bloodstoneSquads -= huntsUntilBloodstone;
+				bloodstoneSquads = Math.max(0, bloodstoneSquads);
+			}
+			var bloodstone = this.game.resPool.addResEvent("bloodstone", this.game.math.binominalRandomInteger(bloodstoneSquads, 0.0005 * bloodstoneRatio));
+			if (bloodstone > 0) {
+				this.game.msg($I("village.msg.hunt.bloodstone", [this.game.getDisplayValueExt(bloodstone)]), "important", "ironWill", true);
 			}
 		}
 

--- a/res/i18n/en.json
+++ b/res/i18n/en.json
@@ -2104,6 +2104,7 @@
     "village.msg.hunt.furs": "+{0} furs",
     "village.msg.hunt.gold": "+{0} gold",
     "village.msg.hunt.ivory": "+{0} ivory",
+    "village.msg.hunt.bloodstone": "+{0} bloodstone!",
     "village.msg.hunt.success": "Your hunters have returned",
     "village.msg.kitten": "kitten",
     "village.msg.kittens": "kittens",


### PR DESCRIPTION
* show bloodstone gains together with regular hunting rewards
* fix the exploit where sending multiple hunts with 0 bloodstone will apply the 5% chance to each of them

the implementation might be a little overkill? it would be possible to use a simple for loop instead of geometricRandom, but 1) geometricRandom isn't very complex actually, and 2) i feel like it might be useful in other situations, if there ever is an event with a very small probability (so that a for-loop would be quite slow).

if you happen to get 2 bloodstones when hunting at 0, the log says both "+1 bloodstone!" and "Your hunters have brought you a strange gift". imo that's fine (the first bloodstone is a gift and the other one is a regular reward), but maybe you'd want to phrase it differently somehow.