### PR TITLE
make the IW catpower upgrades additive + show them in tooltips

### DIFF
--- a/core.js
+++ b/core.js
@@ -2249,7 +2249,10 @@ dojo.declare("com.nuclearunicorn.game.ui.BuildingStackableBtnController", com.nu
 			var zebraOutpostMeta = this.game.bld.getBuildingExt("zebraOutpost").meta;
 			zebraOutpostMeta.calculateEffects(zebraOutpostMeta, this.game);
 			zebraOutpostMeta.jammed = false;
-			this.game.upgrade({policies : ["sharkRelationsBotanists"]});
+			this.game.upgrade({
+				policies: ["sharkRelationsBotanists"],
+				upgrades: ["huntingArmor", "bolas", "compositeBow"]
+			});
 			this.game.diplomacy.onLeavingIW();
 		}
 

--- a/js/buildings.js
+++ b/js/buildings.js
@@ -2573,21 +2573,6 @@ dojo.declare("classes.managers.BuildingsManager", com.nuclearunicorn.core.TabMan
 
 		this.calculatePollutionEffects();
 
-		/*
-		 * Manpower hack for Iron Will mode. 1000 manpower is absolutely required for civilisation unlock.
-		 * There may be some microperf tweaks, but let's keep it simple
-		 */
-		this.game.bld.effectsBase["manpowerMax"] = 100;
-		if (this.game.ironWill){
-			if (this.game.workshop.get("huntingArmor").researched){
-				this.game.bld.effectsBase["manpowerMax"] = 1000;
-			} else if (this.game.workshop.get("bolas").researched){
-				this.game.bld.effectsBase["manpowerMax"] = 400;
-			} else if (this.game.workshop.get("compositeBow").researched){
-				this.game.bld.effectsBase["manpowerMax"] = 200;
-			}
-		}
-
 		if (rerender){
 			this.game.render();
 		}

--- a/js/workshop.js
+++ b/js/workshop.js
@@ -673,10 +673,15 @@ dojo.declare("classes.managers.WorkshopManager", com.nuclearunicorn.core.TabMana
 		label: $I("workshop.compositeBow.label"),
 		description: $I("workshop.compositeBow.desc"),
 		effects: {
-			"manpowerJobRatio" : 0.5
+			"manpowerJobRatio" : 0.5,
+			"manpowerMax": 0
 		},
 		calculateEffects: function(self, game){
 			self.effects["manpowerJobRatio"] = 0.5 * (1 + game.getEffect("weaponEfficency")); //weaponEfficency can't go beyond -1, see challenges.js for more info
+			// give a small amount of catpower storage in iron will.
+			// together with bolas and huntingArmor, this makes the base catpower
+			// max 1000 (when at 0 paragon), which is necessary for unlocking trading
+			self.effects["manpowerMax"] = game.ironWill ? 100 : 0;
 		},
 		prices:[
 			{ name : "wood", val: 200 },
@@ -718,7 +723,11 @@ dojo.declare("classes.managers.WorkshopManager", com.nuclearunicorn.core.TabMana
 		label: $I("workshop.bolas.label"),
 		description: $I("workshop.bolas.desc"),
 		effects: {
-			"hunterRatio" : 1
+			"hunterRatio" : 1,
+			"manpowerMax": 0
+		},
+		calculateEffects: function(self, game){
+			self.effects["manpowerMax"] = game.ironWill ? 200 : 0;
 		},
 		prices:[
 			{ name : "wood", val: 50 },
@@ -731,7 +740,11 @@ dojo.declare("classes.managers.WorkshopManager", com.nuclearunicorn.core.TabMana
 		label: $I("workshop.huntingArmor.label"),
 		description: $I("workshop.huntingArmor.desc"),
 		effects: {
-			"hunterRatio" : 2
+			"hunterRatio" : 2,
+			"manpowerMax": 0
+		},
+		calculateEffects: function(self, game){
+			self.effects["manpowerMax"] = game.ironWill ? 600 : 0;
 		},
 		prices:[
 			{ name : "iron", val: 750 },


### PR DESCRIPTION
This makes it so that each of the catpower buffs in IW gives a specific amount of max catpower (as opposed to the previous code, where the max catpower was based on the highest upgrade you had). Also, the buffs are now regular effects, so they are visible in the upgrade tooltips.

I checked that my max catpower in IW (with all 3 upgrades) stayed the same before and after this patch, and that it was correctly updated when I broke IW.