### PR TITLE
make building a marker immediately unlock necrocorns when in Unicorn Tears

### DIFF
--- a/js/religion.js
+++ b/js/religion.js
@@ -1865,6 +1865,11 @@ dojo.declare("com.nuclearunicorn.game.ui.ZigguratBtnController", com.nuclearunic
 		if (!counter) {
 			return; //Skip undo if nothing was built
 		}
+		// markers unlock necrocorns, but only in UT challenge
+		// (so the necrocorn tooltip has a countdown to the end of the challenge)
+		if (model.metadata.name == "marker" && this.game.challenges.isActive("unicornTears")) {
+			game.resPool.get("necrocorn").unlocked = true;
+		}
 		var undo = this.game.registerUndoChange();
 		undo.addEvent(this.game.religion.id, {
 			action: "buildZU",

--- a/js/religion.js
+++ b/js/religion.js
@@ -885,6 +885,12 @@ dojo.declare("classes.managers.ReligionManager", com.nuclearunicorn.core.TabMana
 		},
 		calculateEffects: function(self, game) {
 			self.effects["corruptionRatio"] = 0.000001 * (1 + game.getEffect("corruptionBoostRatioChallenge")); //LDR specified in challenges.js
+
+			// markers immediately unlock necrocorns, but only in UT challenge
+			// (so that the necrocorn tooltip has a countdown to the end of the challenge).
+			if (self.val > 0 && game.challenges.isActive("unicornTears")) {
+				game.resPool.get("necrocorn").unlocked = true;
+			}
 		},
 		unlocked: false,
 		unlocks: {
@@ -1864,11 +1870,6 @@ dojo.declare("com.nuclearunicorn.game.ui.ZigguratBtnController", com.nuclearunic
 		var counter = this.inherited(arguments);
 		if (!counter) {
 			return; //Skip undo if nothing was built
-		}
-		// markers unlock necrocorns, but only in UT challenge
-		// (so the necrocorn tooltip has a countdown to the end of the challenge)
-		if (model.metadata.name == "marker" && this.game.challenges.isActive("unicornTears")) {
-			game.resPool.get("necrocorn").unlocked = true;
 		}
 		var undo = this.game.registerUndoChange();
 		undo.addEvent(this.game.religion.id, {


### PR DESCRIPTION
This way, the "to next necrocorn" line in the tooltip can serve as a countdown to the end of the challenge.

I limited it to the unicorn tears challenge, because otherwise it'd trigger on someone's first run too, which I feel isn't really necessary or desired (it might ruin the surprise of what markers do). By the time one is doing UT though, necrocorns should be quite familiar already.