### PR TITLE
hide unicorn/alicorn rift messages if they are already capped

### DIFF
--- a/js/calendar.js
+++ b/js/calendar.js
@@ -633,18 +633,24 @@ dojo.declare("com.nuclearunicorn.game.Calendar", null, {
 
 		var riftChance = this.game.getEffect("riftChance");	//5 OPTK
 		if (this.game.rand(10000) < riftChance * 10000 * unicornChanceRatio){
+			//10% of ziggurat buildings bonus
 			var unicornBonus = 500 * (1 + this.game.getEffect("unicornsRatioReligion") * 0.1);
-			this.game.msg($I("calendar.msg.rift", [this.game.getDisplayValueExt(unicornBonus)]), "notice", "unicornRift");
+			var unicornsGain = this.game.resPool.addResEvent("unicorns", unicornBonus);
 
-			this.game.resPool.addResEvent("unicorns", unicornBonus);	//10% of ziggurat buildings bonus
+			if (unicornsGain > 0) {
+				this.game.msg($I("calendar.msg.rift", [this.game.getDisplayValueExt(unicornsGain)]), "notice", "unicornRift");
+			}
+
 		}
 		//----------------------------------------------
 		var aliChance = this.game.getEffect("alicornChance");	//0.2 OPTK
 		aliChance *= 1 + this.game.getLimitedDR(this.game.getEffect("alicornPerTickRatio"), 1.2);
 		if (this.game.rand(100000) < aliChance * 100000){
-			this.game.msg($I("calendar.msg.alicorn"), "important", "alicornRift");
+			var alicornsGain = this.game.resPool.addResEvent("alicorn", 1);
+			if (alicornsGain > 0) {
+				this.game.msg($I("calendar.msg.alicorn"), "important", "alicornRift");
+			}
 
-			this.game.resPool.addResEvent("alicorn", 1);
 			this.game.upgrade({
 				zigguratUpgrades: ["skyPalace", "unicornUtopia", "sunspire"]
 			});


### PR DESCRIPTION
in unicorn tears, you can still get unicorn rifts / alicorn descents when the respective resources are capped. i changed it so that the rift message is hidden if you didn't gain anything from it. (and as a bonus, for unicorn rifts i made it display the correct amount of gained unicorns. the alicorn message doesn't have a number in it though, and i didn't feel it was necessary to add a number there just for this.)