### PR TITLE
fix: Sleek theme in Steam

### DIFF
--- a/res/theme_sleek.css
+++ b/res/theme_sleek.css
@@ -137,6 +137,7 @@
     bottom: 0px;
     right: 0px;
     min-width: 1180px;
+    max-width: unset;
     width: auto !important;
     overflow: hidden;
 }


### PR DESCRIPTION
Seems like the `max-width` from another rule prevents the desired layout. I assume that this has no negative effects on browser environment, but I haven't checked.