### PR TITLE
fix: Catnip theme readability and census placeholder fixes

### DIFF
--- a/js/village.js
+++ b/js/village.js
@@ -4327,7 +4327,7 @@ dojo.declare("classes.ui.village.Census", null, {
 	//TODO: behavior if in anarchy challenge?
 	getGovernmentInfo: function() {
 		var retVal = {
-			leaderInfo: "%username%",
+			leaderInfo: $I("village.census.lbl.noLeader"),
 			expInfo: "",
 			jobBonusInfo: "",
 		};

--- a/res/i18n/en.json
+++ b/res/i18n/en.json
@@ -2024,6 +2024,7 @@
     "village.census.lbl.festival.duration": "Festival duration",
     "village.census.lbl.happiness": "Happiness",
     "village.census.lbl.leader": "Leader",
+    "village.census.lbl.noLeader": "No leader",
     "village.census.btn.favorite": "Favorite kitten",
     "village.census.btn.leader": "Make a leader",
     "village.census.btn.promote": "Promote",

--- a/res/theme_catnip.css
+++ b/res/theme_catnip.css
@@ -364,6 +364,9 @@ body.scheme_catnip {
 	background-color: transparent;
 	backdrop-filter: none; /* default : backdrop-filter: blur(2px); */
 }
+.scheme_catnip .button_tooltip.login-popup { /* save/login popup: default falls back to white --page-background-color */
+	background-color: rgba(38, 40, 31, 0.9) !important; /* match tooltip window; !important to beat default.css */
+}
 .scheme_catnip .button_tooltip div { /* tooltip window == left column: right text | center column:highlighting text */
 	color: #ebede5;
 }
@@ -836,6 +839,10 @@ body.scheme_catnip {
 .scheme_catnip .container .name.variety-spots { /* tacheté */
 	border: 1px dotted #c49474;
 	padding: 0 5px;
+}
+.scheme_catnip .container .currentLeader .name { /* leader panel sits on the light bg, not the dark census-block, so the light fur colors wash out; use the theme's standard dark text color and readable face instead */
+	font-family: 'Open Sans', sans-serif;
+	color: #3c4128;
 }
 .scheme_catnip .btn.modern.disabled a.auto-on {
 	color: #005f05;


### PR DESCRIPTION
Did some more cleanup on Catnip....

- Catnip save/login popup: gave it the dark tooltip-window background instead of falling back to the default white --page-background-color, which left its light text unreadable.
- Catnip leader name: rendered .currentLeader .name in the theme's standard dark text color and the readable Open Sans face, since the light fur colors (tuned for the dark census-block) washed out on the light government panel.
- Census: show a localized "No leader" string instead of the leftover "%username%" placeholder, which was never substituted anywhere.

One possible issue here - it seems like "no leader" being "%username%" meant that it did not propogate to other translations including the new crowdin...

### Before:

<img width="614" height="151" alt="image" src="https://github.com/user-attachments/assets/f271e36b-156e-4deb-a42f-a802ca96ed7d" />
<img width="614" height="151" alt="image" src="https://github.com/user-attachments/assets/72c3fb3d-251f-4b7b-b47c-09699458a217" />
<img width="608" height="105" alt="image" src="https://github.com/user-attachments/assets/22eb1f31-1330-4a93-a0a6-f7e1dc73a96b" />

### After:
<img width="602" height="150" alt="image" src="https://github.com/user-attachments/assets/f3d2a153-04e1-49b6-a54d-61fd8d416a66" />
<img width="492" height="93" alt="image" src="https://github.com/user-attachments/assets/7d627a11-aa38-4b29-8e13-727305f363fc" />
<img width="622" height="245" alt="image" src="https://github.com/user-attachments/assets/582dbd03-c139-404e-b478-e3064f2363e9" />


