### PR TITLE
fix: re-render layout after loading save from server

### DIFF
--- a/game.js
+++ b/game.js
@@ -369,6 +369,8 @@ dojo.declare("classes.game.Server", null, {
 
 			self.game.load();
 			self.game.msg($I("save.import.msg"));
+
+			self.game.render();
 		});
 	},
 


### PR DESCRIPTION
When you load a save from the server, it doesn't do an immediate re-draw of the screen, so tabs you might expect are not there.

Add a re-render after loading save from server to match the behavior of loading from the base64...

