### PR TITLE
clear the undo state when loading a save

### DIFF
--- a/game.js
+++ b/game.js
@@ -2378,6 +2378,9 @@ dojo.declare("com.nuclearunicorn.game.ui.GamePage", null, {
 		}
 
 		this.globalEffectsCached = {};
+
+		this.undoChange = null;
+		this._publish("server/undoStateChanged");
 	},
 
 	_publish: function(topic, arg){


### PR DESCRIPTION
without this, you could undo an action from a different save file, which could lead to some funny effects (e.g. negative amounts of some buildings).