### PR TITLE
use actionOnCompletion for awarding basges in pacifism/atheism

### DIFF
--- a/game.js
+++ b/game.js
@@ -4785,13 +4785,6 @@ dojo.declare("com.nuclearunicorn.game.ui.GamePage", null, {
 		var game = this;
 		game.ui.confirm($I("reset.confirmation.title"), msg, function() {
 			game.challenges.onRunReset();
-			if (game.challenges.isActive("atheism") && game.time.getVSU("cryochambers").on > 0) {
-				game.challenges.getChallenge("atheism").researched = true;
-
-				if (game.ironWill) {
-					game.achievements.unlockBadge("ivoryTower");
-				}
-			}
 			if (game.calendar.day < 0) {
 				game.achievements.unlockBadge("abOwo");
 			}

--- a/js/challenges.js
+++ b/js/challenges.js
@@ -179,6 +179,11 @@ dojo.declare("classes.managers.ChallengesManager", com.nuclearunicorn.core.TabMa
 		checkCompletionConditionOnReset: function(game){
 			return game.time.getVSU("cryochambers").on > 0 || game.bld.get("stasisPod").on > 0;
 		},
+		actionOnCompletion: function(game){
+			if (game.ironWill) {
+				game.achievements.unlockBadge("ivoryTower");
+			}
+		},
 		reserveDelay: true
 	},{
 		name: "1000Years",
@@ -292,11 +297,17 @@ dojo.declare("classes.managers.ChallengesManager", com.nuclearunicorn.core.TabMa
 			self.effects["tradeKnowledgeRatio"] = self.getTradeBonusEffect(game);
 		},
 		checkCompletionConditionOnReset: function(game){
+			// hack: this code is here as a sort of general "code that runs on
+			// reset when pacifism is active" hook. it intentionally does not
+			// require the completion condition to actually be met. (otherwise
+			// it might be too difficult to get this basge if one already has
+			// a lot of pacifism completions.)
 			if (game.diplomacy.baseManpowerCost > 0) { // BSK+IW precaution
 				if (!game.village.sim.hadKittenHunters && game.stats.getStatCurrent("totalTrades").val > 0){
-					game.achievements.unlockBadge("cleanPaws"); //hack
+					game.achievements.unlockBadge("cleanPaws");
 				}
 			}
+
 			return game.science.getPolicy("outerSpaceTreaty").researched;
 		},
 		upgrades: {


### PR DESCRIPTION
Aside from being cleaner, this has some semantic differences:
* makes ivoryTower actually attainable as intended (previously the duplicated unlock condition meant the basge was still impossible even though winning IW atheism was now possible)
* ~~i think it also fixes an exploit where you could get cleanPaws by resetting before you had actually won pacifism (since the cleanPaws check ran before the win condition check)~~  
  turns out this was intentional, so i added a comment that explains this.