### PR TITLE
Update loadouts

### DIFF
--- a/js/jsx/left.jsx.js
+++ b/js/jsx/left.jsx.js
@@ -776,6 +776,7 @@ WPins = React.createClass({
             if (loadout.pinned){
                 pins.push({
                     title: $I("left.loadout.do", [loadout.title]),
+                    highlight: loadout.lastSelected,
                     handler: function(loadout){ 
                         loadout.setLoadout(true);
                     }.bind(this, loadout)
@@ -789,6 +790,9 @@ WPins = React.createClass({
         var pinLinks = [];
         for (var i in pins){
             var pin = pins[i];
+            if (pin.highlight) {
+                pin.title = "> " + pin.title + " <";
+            }
             pinLinks.push(
                 $r("div", {className:"pin-link"},
                     $r("a", {href:"#", onClick: pin.handler},

--- a/js/village.js
+++ b/js/village.js
@@ -271,12 +271,15 @@ dojo.declare("classes.managers.VillageManager", com.nuclearunicorn.core.TabManag
 		}
 	},
 
-	assignJob: function(job, amt){
+	assignJob: function(job, amt, optimize){
+		if (optimize === undefined) {
+			optimize = true;
+		}
 		var jobRef = this.getJob(job.name); 	//probably will fix missing ref on loading
 		amt = Math.min(amt, this.getFreeKittens(), this.getJobLimit(job.name) - jobRef.value);
 
 		if (amt > 0) {
-			this.sim.assignJob(job.name, amt);
+			this.sim.assignJob(job.name, amt, optimize);
 			jobRef.value += amt;
 			if (job.name == "engineer") {
 				this.game.workshopTab.updateTab();
@@ -2816,9 +2819,9 @@ dojo.declare("classes.village.KittenSim", null, {
 	 * • With leader and register tech buy : a free kitten with Highest skill level in this job or any free if none
 	 * • Else : the first free kitten
 	 */
-	assignJob: function(job, amt){
+	assignJob: function(job, amt, optimize){
 		var freeKittens = [];
-		var optimizeJobs = this.game.workshop.get("register").researched && this.game.village.leader;
+		var optimizeJobs = this.game.workshop.get("register").researched && this.game.village.leader && optimize;
 
 		for (var i = this.kittens.length - 1; i >= 0; i--) {
 			var kitten = this.kittens[i];
@@ -3431,6 +3434,7 @@ dojo.declare("com.nuclearunicorn.game.village.Loadout", null, {
 	engineerJobs: null,
 	pinned: false,
 	isDefault: false,
+	lastSelected: false,
 
 	constructor: function(game, isDefault){
 
@@ -3467,7 +3471,8 @@ dojo.declare("com.nuclearunicorn.game.village.Loadout", null, {
 			leaderTrait: this.leaderTrait,
 			leaderJob: this.leaderJob,
 			pinned: this.pinned,
-			isDefault: this.isDefault
+			isDefault: this.isDefault,
+			lastSelected: this.lastSelected
 		};
 	},
 
@@ -3479,6 +3484,7 @@ dojo.declare("com.nuclearunicorn.game.village.Loadout", null, {
 		this.leaderJob = data.leaderJob;
 		this.pinned = 	data.pinned;
 		this.isDefault = data.isDefault;
+		this.lastSelected = data.lastSelected;
 	},
 
 	saveLoadout: function(setDefault) {
@@ -3539,7 +3545,7 @@ dojo.declare("com.nuclearunicorn.game.village.Loadout", null, {
 			}
 			if (!this.game.village.leader) {
 				if (leaderJob) {
-					kittens[kittens.length - 1].job = leaderJob
+					kittens[kittens.length - 1].job = leaderJob;
 					this.game.village.getJob(leaderJob).value++;
 				}
 				this.game.village.makeLeader(kittens[kittens.length - 1]);
@@ -3549,26 +3555,37 @@ dojo.declare("com.nuclearunicorn.game.village.Loadout", null, {
 
 	setLoadout: function(setLeader) {
 		this.game.village.clearJobs(true);
-		if (this.game.village.leader){
+		if (this.game.village.leader) {
 			this.game.village.leader.isLeader = false;
 			this.game.village.leader = null;
 		}
+		var loadouts = this.game.village.loadoutController.loadouts;
+		for (var i in loadouts) {
+			loadouts[i].lastSelected = false;
+		}
+		this.lastSelected = true; //Used for highlighting the last picked loadout
+
 		var kittens = this.game.village.sim.kittens;
 		var workCapableKittens = this.game.village.getDiligentKittens();
 		var loadoutJobsSum = 0;
 		var jobsFiltered = [];
 		var leaderJob = this.leaderJob;
+		var jobs = this.jobs;
 
-		this.game.village.sim.sortKittensByExp();
-
-		for (var i in this.jobs) {
-			var job = this.jobs[i];
+		for (var i in jobs) {
+			var job = jobs[i];
 
 			if (this.game.village.getJob(job.name).unlocked && job.value > 0) { //Check if the job is unlocked
 				var jobLimit = this.game.village.getJobLimit(job.name);
 				if (jobLimit > 0) {  //If the job limit is 0 (No factories built for engineers), then don't add it
 					loadoutJobsSum += job.value;
-					jobsFiltered.push({name : job.name, value : job.value, jobLimit : this.game.village.getJobLimit(job.name)});
+					var filteredJob = {name : job.name, value : job.value, jobLimit : this.game.village.getJobLimit(job.name)};
+					if (filteredJob.name == "engineer") {
+						jobsFiltered.unshift(filteredJob);
+					} else {
+						jobsFiltered.push(filteredJob);
+					}
+					
 				} else if (job.name == leaderJob) {
 					leaderJob = null;
 				}
@@ -3588,6 +3605,7 @@ dojo.declare("com.nuclearunicorn.game.village.Loadout", null, {
 			}
 		} 
 
+		this.game.village.sim.sortKittensByExp(); //Sort kittens so the leader is assigned the highest possible rank
 		this.assignLoadoutLeader(kittens, leaderJob);
 
 		var limitedJobs = 0;
@@ -3599,7 +3617,7 @@ dojo.declare("com.nuclearunicorn.game.village.Loadout", null, {
 					jobLimit--;
 				}
 				if (jobLimit > 0) {
-					this.game.village.assignJob(this.game.village.getJob(job.name), jobLimit);
+					this.game.village.assignJob(this.game.village.getJob(job.name), jobLimit, false);
 					loadoutJobsSum -= job.value;
 					jobsFiltered.splice(jobsFiltered.indexOf(job), 1);			
 					limitedJobs += jobLimit;
@@ -3612,20 +3630,26 @@ dojo.declare("com.nuclearunicorn.game.village.Loadout", null, {
 		//Assign jobs
 
 		jobRatio = (workCapableKittens - limitedJobs) / loadoutJobsSum;
-
-		jobsFiltered.sort(function(a, b){return b.value - a.value;});	//Sort the jobs, so the job with the most weight gets the most priority
-
-		for (var i in jobsFiltered){	//Assign 1 kitten to each job so at least one worker is assigned.
-			this.game.village.assignJob(this.game.village.getJob(jobsFiltered[i].name), 1);
+		for (var i in jobsFiltered) {
+			jobsFiltered[i].value *= jobRatio;
 		}
 
+		this.game.village.sim.kittens.reverse(); //Reverse kittens array, so the high rank kittens are not assigned here
+		for (var i in jobsFiltered){	//Assign 1 kitten to each job so at least one worker is assigned.
+			if (jobsFiltered[i].name != "engineer") {
+				this.game.village.assignJob(this.game.village.getJob(jobsFiltered[i].name), 1, false);
+			} else {
+				jobsFiltered[i].value++; //This Engineer will be added later so they get a high rank
+			}
+		}
+		this.game.village.sim.kittens.reverse(); //Reverse again to assign highest rank kittens first as engineers
 		
 		for (var i in jobsFiltered) {
 			job = jobsFiltered[i];
 
-			var valueFiltered = Math.floor(jobRatio * (job.value)) - 1;
+			var valueFiltered = Math.floor(job.value) - 1; //Already added at least 1 kitten to each job so add 1 less
 			if (valueFiltered > 0){
-				this.game.village.assignJob(this.game.village.getJob(job.name), valueFiltered);
+				this.game.village.assignJob(this.game.village.getJob(job.name), valueFiltered, false);
 			}			
 		}
 
@@ -3635,7 +3659,7 @@ dojo.declare("com.nuclearunicorn.game.village.Loadout", null, {
 			for (var i in jobsFiltered) {
 				if (freeKittens > 0){
 					job = jobsFiltered[i];
-					this.game.village.assignJob(this.game.village.getJob(job.name), 1);
+					this.game.village.assignJob(this.game.village.getJob(job.name), 1, false);
 					freeKittens--;
 				} else {
 					break;
@@ -4895,8 +4919,12 @@ dojo.declare("com.nuclearunicorn.game.ui.tab.Village", com.nuclearunicorn.game.u
 	},
 
 	createLoadoutBtn: function(loadout, game) {
+		var btnName = loadout.title;
+		if (loadout.lastSelected) {
+			btnName = "> " + btnName + " <";
+		}
 		var btn = new com.nuclearunicorn.game.ui.LoadoutButton({
-			name : loadout.title,
+			name : btnName,
 			loadout : loadout,
 			controller: new com.nuclearunicorn.game.ui.LoadoutButtonController(game)
 		}, game);
@@ -4979,7 +5007,6 @@ dojo.declare("com.nuclearunicorn.game.ui.tab.Village", com.nuclearunicorn.game.u
 			style: {
 				float: "right"
 			},
-			title: "Delete all loadouts"
 		}, loadoutDiv);
 
 		dojo.connect(this.deleteAllLoadoutHref, "onclick", this,  function(){
@@ -4997,7 +5024,6 @@ dojo.declare("com.nuclearunicorn.game.ui.tab.Village", com.nuclearunicorn.game.u
 		this.toggleDefaultLoadoutHref = dojo.create("a", { // Restore all default loadouts
 			href: "#", innerHTML: toggleText,
 			className: "loadoutHref",
-			title: "Default loadouts"
 		}, loadoutDiv);
 
 		dojo.connect(this.toggleDefaultLoadoutHref, "onclick", this,  function(){
@@ -5030,7 +5056,6 @@ dojo.declare("com.nuclearunicorn.game.ui.tab.Village", com.nuclearunicorn.game.u
 			style: {
 				float: "right"
 			},
-			title: "Create Loadout"
 		}, tdTop2);
 
 		dojo.connect(this.createLoadoutHref, "onclick", this,  function(){

--- a/js/village.js
+++ b/js/village.js
@@ -3465,6 +3465,7 @@ dojo.declare("com.nuclearunicorn.game.village.Loadout", null, {
 			jobs: saveJobs,
 			engineerJobs: saveEngineerJobs,
 			leaderTrait: this.leaderTrait,
+			leaderJob: this.leaderJob,
 			pinned: this.pinned,
 			isDefault: this.isDefault
 		};
@@ -3475,6 +3476,7 @@ dojo.declare("com.nuclearunicorn.game.village.Loadout", null, {
 		this.jobs = 	data.jobs;
 		this.engineerJobs = data.engineerJobs;
 		this.leaderTrait = data.leaderTrait;
+		this.leaderJob = data.leaderJob
 		this.pinned = 	data.pinned;
 		this.isDefault = data.isDefault;
 	},
@@ -3521,12 +3523,40 @@ dojo.declare("com.nuclearunicorn.game.village.Loadout", null, {
 		}
 	},
 
+	assignLoadoutLeader: function(kittens, leaderJob, setLeader){
+		if (setLeader && this.leaderTrait && !this.game.challenges.isActive("anarchy")) {
+			
+			for (var i = kittens.length - 1; i >= 0; i--) {
+				if (kittens[i].trait.name == this.leaderTrait.name) {
+					kittens[i].job = leaderJob
+					var temp = this.game.village.getJob(leaderJob)	
+					this.game.village.getJob(leaderJob).value++ //Have to increase the job value, else the getFreeKittens function works incorrectly. TODO: Maybe make a function to assign a kitten to a specific job
+					this.game.village.makeLeader(kittens[i]);
+					
+					break;
+				}
+			}
+			if (!this.game.village.leader) {
+				kittens[i].job = leaderJob
+				this.game.village.getJob(leaderJob).value++
+				this.game.village.makeLeader(kittens[0]);
+			}
+		}
+	},
+
 	setLoadout: function(setLeader) {
 		this.game.village.clearJobs(true);
+		if(this.game.village.leader){
+			this.game.village.leader.isLeader = false
+			this.game.village.leader = null
+		}
 		var kittens = this.game.village.sim.kittens;
 		var workCapableKittens = this.game.village.getDiligentKittens();
 		var loadoutJobsSum = 0;
 		var jobsFiltered = [];
+		var leaderJob = this.leaderJob;
+
+		this.game.village.sim.sortKittensByExp();
 
 		for (var i in this.jobs) {
 			var job = this.jobs[i];
@@ -3538,17 +3568,38 @@ dojo.declare("com.nuclearunicorn.game.village.Loadout", null, {
 		}
 		var jobRatio = workCapableKittens / loadoutJobsSum;
 
+		var theocracy = this.game.science.getPolicy("theocracy"); //Check if Order of the stars is active. If it is, change the leader job to priest
+			if (theocracy.researched && theocracy.requiredLeaderJob != leaderJob){
+				leaderJob = this.game.village.getJob(theocracy.requiredLeaderJob).name;
+			}
+			
+
 		var limitedJobs = 0;
 		for (i in jobsFiltered) {	//Check the filtered jobs if they are limited (engineers) and if the kittens assigned would be over the limit, assign the limit and remove the job from the filter
 			job = jobsFiltered[i];
 			var jobLimit = this.game.village.getJobLimit(job.name);
-			if (jobLimit < job.value * jobRatio){
-				this.game.village.assignJob(this.game.village.getJob(job.name), jobLimit);
-				loadoutJobsSum -= job.value;
-				jobsFiltered.splice(jobsFiltered.indexOf(job), 1);			
-				limitedJobs += jobLimit;
+			if (jobLimit < job.value * jobRatio && jobLimit > 0){
+				if(leaderJob == job.name) {  //If the leader was assigned this job, remove one kitten.
+					jobLimit--
+				}
+				this.assignLoadoutLeader(kittens, leaderJob, setLeader)
+				if (jobLimit > 0) {
+					this.game.village.assignJob(this.game.village.getJob(job.name), jobLimit);
+					loadoutJobsSum -= job.value;
+					jobsFiltered.splice(jobsFiltered.indexOf(job), 1);			
+					limitedJobs += jobLimit;
+				}
+			} else if(leaderJob == job.name && jobsFiltered && jobLimit <= 0) {
+				leaderJob = jobsFiltered[0].name //If the job limit is 0 (No Factories built) set another job
 			}
 		}
+
+		//Assign leader
+
+		if(!this.game.village.leader) {
+			this.assignLoadoutLeader(kittens, leaderJob, setLeader)
+		}
+
 
 		//Assign jobs
 
@@ -3626,34 +3677,7 @@ dojo.declare("com.nuclearunicorn.game.village.Loadout", null, {
 				}				
 			}
 		}
-
-		//Assign leader
-
-		if (setLeader && this.leaderTrait && !this.game.challenges.isActive("anarchy")) {
-			this.game.village.sim.sortKittensByExp();
-			var theocracy = this.game.science.getPolicy("theocracy");
-			var tempKitten = null;
-			for (var i = kittens.length - 1; i >= 0; i--) {
-				if (kittens[i].trait.name == this.leaderTrait.name) {
-					if ((theocracy.researched) && (kittens[i].job != theocracy.requiredLeaderJob)){
-						continue;
-					}
-
-					if (kittens[i].job == this.leaderJob){
-						this.game.village.makeLeader(kittens[i]);
-						tempKitten = null;
-						break;
-					} else if (!tempKitten){
-						tempKitten = kittens[i];
-					}		
-					
-				}
-			}
-			if (tempKitten){ // If there is no kitten that has the saved job and trait together, assign the first kitten with the trait. 
-				this.game.village.makeLeader(tempKitten);
-			}
-		}
-
+		//this.game.village.optimizeJobs();
 		this.game.render();
 	},
 

--- a/js/village.js
+++ b/js/village.js
@@ -2820,6 +2820,9 @@ dojo.declare("classes.village.KittenSim", null, {
 	 * • Else : the first free kitten
 	 */
 	assignJob: function(job, amt, optimize){
+		if (optimize === undefined) {
+			optimize = true;
+		}
 		var freeKittens = [];
 		var optimizeJobs = this.game.workshop.get("register").researched && this.game.village.leader && optimize;
 

--- a/js/village.js
+++ b/js/village.js
@@ -3637,23 +3637,23 @@ dojo.declare("com.nuclearunicorn.game.village.Loadout", null, {
 			jobsFiltered[i].value *= jobRatio;
 		}
 
-		this.game.village.sim.kittens.reverse(); //Reverse kittens array, so the high rank kittens are not assigned here
-		for (var i in jobsFiltered){	//Assign 1 kitten to each job so at least one worker is assigned.
-			if (jobsFiltered[i].name != "engineer") {
-				this.game.village.assignJob(this.game.village.getJob(jobsFiltered[i].name), 1, false);
-			} else {
-				jobsFiltered[i].value++; //This Engineer will be added later so they get a high rank
-			}
-		}
-		this.game.village.sim.kittens.reverse(); //Reverse again to assign highest rank kittens first as engineers
-		
 		for (var i in jobsFiltered) {
+			var optimize = true;
 			job = jobsFiltered[i];
-
-			var valueFiltered = Math.floor(job.value) - 1; //Already added at least 1 kitten to each job so add 1 less
+			var valueFiltered = Math.floor(job.value) - 1; //1 less, so all jobs are assigned to at least 1 kitten later
+			
+			if (job.name == "engineer") {
+				optimize = false;
+			}
 			if (valueFiltered > 0){
-				this.game.village.assignJob(this.game.village.getJob(job.name), valueFiltered, false);
+				this.game.village.assignJob(this.game.village.getJob(job.name), valueFiltered, optimize);
 			}			
+		}
+
+		for (var i in jobsFiltered){ //Assign at least 1 kitten to all jobs
+			if (jobsFiltered[i].name != "engineer") { //Engineers will only be assigned to the highest ranks
+				this.game.village.assignJob(this.game.village.getJob(jobsFiltered[i].name), 1);
+			}
 		}
 
 		var freeKittens = this.game.village.getFreeKittens();
@@ -3662,7 +3662,7 @@ dojo.declare("com.nuclearunicorn.game.village.Loadout", null, {
 			for (var i in jobsFiltered) {
 				if (freeKittens > 0){
 					job = jobsFiltered[i];
-					this.game.village.assignJob(this.game.village.getJob(job.name), 1, false);
+					this.game.village.assignJob(this.game.village.getJob(job.name), 1);
 					freeKittens--;
 				} else {
 					break;
@@ -3676,8 +3676,10 @@ dojo.declare("com.nuclearunicorn.game.village.Loadout", null, {
 		var craftsSum = 0;
 		for (var i in this.engineerJobs) {
 			var engineerJob = this.engineerJobs[i];
+			var craft = this.game.workshop.getCraft(engineerJob.craft);
+			engineerJob.tier = craft.tier;
 
-			if (this.game.workshop.getCraft(engineerJob.craft).unlocked && engineerJob.value > 0) {
+			if (craft.unlocked && engineerJob.value > 0) {
 				craftsSum += engineerJob.value;
 				craftsFiltered.push(engineerJob);
 			}
@@ -3685,19 +3687,19 @@ dojo.declare("com.nuclearunicorn.game.village.Loadout", null, {
 
 		var engineerRatio = this.game.village.getFreeEngineers() / craftsSum;
 
-		craftsFiltered.sort(function(a, b){return b.value - a.value;});
-
-		for (var i in craftsFiltered){
-			this.assignCraftJob(this.game.workshop.getCraft(craftsFiltered[i].craft), 1);
-		}
+		craftsFiltered.sort(function(a, b){return b.tier - a.tier;});
 
 		for (var i in craftsFiltered) {
 			var craft = craftsFiltered[i];
 
-			var craftValueFiltered = Math.floor(engineerRatio * (craft.value)) - 1;
+			var craftValueFiltered = Math.floor(engineerRatio * (craft.value)) - 1; //1 less, so all craft jobs are assigned at least 1 kitten later
 			if (craftValueFiltered > 0){
 				this.assignCraftJob(this.game.workshop.getCraft(craft.craft), craftValueFiltered);
 			}
+		}
+
+		for (var i in craftsFiltered){ //Assign at least 1 kitten to all craft jobs
+			this.assignCraftJob(this.game.workshop.getCraft(craftsFiltered[i].craft), 1);
 		}
 
 		var freeEngineers = this.game.village.getFreeEngineers();

--- a/js/village.js
+++ b/js/village.js
@@ -1015,7 +1015,7 @@ dojo.declare("classes.managers.VillageManager", com.nuclearunicorn.core.TabManag
 						delete situationJobs[job];
 					} else {
 						situationJobs[job] = situationJobs[job] - 1;
-					}
+					} 
 				}
 			}
 
@@ -3476,7 +3476,7 @@ dojo.declare("com.nuclearunicorn.game.village.Loadout", null, {
 		this.jobs = 	data.jobs;
 		this.engineerJobs = data.engineerJobs;
 		this.leaderTrait = data.leaderTrait;
-		this.leaderJob = data.leaderJob
+		this.leaderJob = data.leaderJob;
 		this.pinned = 	data.pinned;
 		this.isDefault = data.isDefault;
 	},
@@ -3528,17 +3528,17 @@ dojo.declare("com.nuclearunicorn.game.village.Loadout", null, {
 			
 			for (var i = kittens.length - 1; i >= 0; i--) {
 				if (kittens[i].trait.name == this.leaderTrait.name) {
-					kittens[i].job = leaderJob
-					var temp = this.game.village.getJob(leaderJob)	
-					this.game.village.getJob(leaderJob).value++ //Have to increase the job value, else the getFreeKittens function works incorrectly. TODO: Maybe make a function to assign a kitten to a specific job
+					kittens[i].job = leaderJob;
+					var temp = this.game.village.getJob(leaderJob);
+					this.game.village.getJob(leaderJob).value++; //Have to increase the job value, else the getFreeKittens function works incorrectly. TODO: Maybe make a function to assign a kitten to a specific job
 					this.game.village.makeLeader(kittens[i]);
 					
 					break;
 				}
 			}
 			if (!this.game.village.leader) {
-				kittens[i].job = leaderJob
-				this.game.village.getJob(leaderJob).value++
+				kittens[0].job = leaderJob;
+				this.game.village.getJob(leaderJob).value++;
 				this.game.village.makeLeader(kittens[0]);
 			}
 		}
@@ -3546,9 +3546,9 @@ dojo.declare("com.nuclearunicorn.game.village.Loadout", null, {
 
 	setLoadout: function(setLeader) {
 		this.game.village.clearJobs(true);
-		if(this.game.village.leader){
-			this.game.village.leader.isLeader = false
-			this.game.village.leader = null
+		if (this.game.village.leader){
+			this.game.village.leader.isLeader = false;
+			this.game.village.leader = null;
 		}
 		var kittens = this.game.village.sim.kittens;
 		var workCapableKittens = this.game.village.getDiligentKittens();
@@ -3579,25 +3579,25 @@ dojo.declare("com.nuclearunicorn.game.village.Loadout", null, {
 			job = jobsFiltered[i];
 			var jobLimit = this.game.village.getJobLimit(job.name);
 			if (jobLimit < job.value * jobRatio && jobLimit > 0){
-				if(leaderJob == job.name) {  //If the leader was assigned this job, remove one kitten.
-					jobLimit--
+				if (leaderJob == job.name) {  //If the leader was assigned this job, remove one kitten.
+					jobLimit--;
 				}
-				this.assignLoadoutLeader(kittens, leaderJob, setLeader)
+				this.assignLoadoutLeader(kittens, leaderJob, setLeader);
 				if (jobLimit > 0) {
 					this.game.village.assignJob(this.game.village.getJob(job.name), jobLimit);
 					loadoutJobsSum -= job.value;
 					jobsFiltered.splice(jobsFiltered.indexOf(job), 1);			
 					limitedJobs += jobLimit;
 				}
-			} else if(leaderJob == job.name && jobsFiltered && jobLimit <= 0) {
-				leaderJob = jobsFiltered[0].name //If the job limit is 0 (No Factories built) set another job
+			} else if (leaderJob == job.name && jobsFiltered && jobLimit <= 0) {
+				leaderJob = jobsFiltered[0].name; //If the job limit is 0 (No Factories built) set another job
 			}
 		}
 
 		//Assign leader
 
-		if(!this.game.village.leader) {
-			this.assignLoadoutLeader(kittens, leaderJob, setLeader)
+		if (!this.game.village.leader) {
+			this.assignLoadoutLeader(kittens, leaderJob, setLeader);
 		}
 
 

--- a/js/village.js
+++ b/js/village.js
@@ -3523,23 +3523,26 @@ dojo.declare("com.nuclearunicorn.game.village.Loadout", null, {
 		}
 	},
 
-	assignLoadoutLeader: function(kittens, leaderJob, setLeader){
-		if (setLeader && this.leaderTrait && !this.game.challenges.isActive("anarchy")) {
+	assignLoadoutLeader: function(kittens, leaderJob){
+		if (this.leaderTrait && !this.game.challenges.isActive("anarchy") && this.game.science.get("civil").researched) { //Check if anarchy is active and if Civil Service if researched
 			
 			for (var i = kittens.length - 1; i >= 0; i--) {
 				if (kittens[i].trait.name == this.leaderTrait.name) {
-					kittens[i].job = leaderJob;
-					var temp = this.game.village.getJob(leaderJob);
-					this.game.village.getJob(leaderJob).value++; //Have to increase the job value, else the getFreeKittens function works incorrectly. TODO: Maybe make a function to assign a kitten to a specific job
+					if (leaderJob) {
+						kittens[i].job = leaderJob;
+						this.game.village.getJob(leaderJob).value++; //Have to increase the job value, else the getFreeKittens function works incorrectly. TODO: Maybe make a function to assign a kitten to a specific job
+					}
 					this.game.village.makeLeader(kittens[i]);
 					
 					break;
 				}
 			}
 			if (!this.game.village.leader) {
-				kittens[0].job = leaderJob;
-				this.game.village.getJob(leaderJob).value++;
-				this.game.village.makeLeader(kittens[0]);
+				if (leaderJob) {
+					kittens[kittens.length - 1].job = leaderJob
+					this.game.village.getJob(leaderJob).value++;
+				}
+				this.game.village.makeLeader(kittens[kittens.length - 1]);
 			}
 		}
 	},
@@ -3561,28 +3564,40 @@ dojo.declare("com.nuclearunicorn.game.village.Loadout", null, {
 		for (var i in this.jobs) {
 			var job = this.jobs[i];
 
-			if (this.game.village.getJob(job.name).unlocked && job.value > 0) {				
-				loadoutJobsSum += job.value;
-				jobsFiltered.push({name : job.name, value : job.value});
+			if (this.game.village.getJob(job.name).unlocked && job.value > 0) { //Check if the job is unlocked
+				var jobLimit = this.game.village.getJobLimit(job.name);
+				if (jobLimit > 0) {  //If the job limit is 0 (No factories built for engineers), then don't add it
+					loadoutJobsSum += job.value;
+					jobsFiltered.push({name : job.name, value : job.value, jobLimit : this.game.village.getJobLimit(job.name)});
+				} else if (job.name == leaderJob) {
+					leaderJob = null;
+				}
+			} else if (job.name == leaderJob) {
+				leaderJob = null;
 			}
 		}
 		var jobRatio = workCapableKittens / loadoutJobsSum;
 
 		var theocracy = this.game.science.getPolicy("theocracy"); //Check if Order of the stars is active. If it is, change the leader job to priest
-			if (theocracy.researched && theocracy.requiredLeaderJob != leaderJob){
-				leaderJob = this.game.village.getJob(theocracy.requiredLeaderJob).name;
+		if (theocracy.researched && theocracy.requiredLeaderJob != leaderJob){
+			leaderJob = this.game.village.getJob(theocracy.requiredLeaderJob).name;
+		}
+		if (!leaderJob) {
+			if (jobsFiltered.length) {
+				leaderJob = jobsFiltered[0].name; //If there was no leaderJob or it was filtered out, set the first job from the filtered list (usually woodcutter)
 			}
-			
+		} 
+
+		this.assignLoadoutLeader(kittens, leaderJob);
 
 		var limitedJobs = 0;
-		for (i in jobsFiltered) {	//Check the filtered jobs if they are limited (engineers) and if the kittens assigned would be over the limit, assign the limit and remove the job from the filter
-			job = jobsFiltered[i];
-			var jobLimit = this.game.village.getJobLimit(job.name);
+		for (i in jobsFiltered) {	//Check the filtered jobs if they are limited (engineers due to factories). If the kittens assigned would be over the limit, assign the limit and remove the job from the filter
+			var job = jobsFiltered[i];
+			var jobLimit = job.jobLimit;
 			if (jobLimit < job.value * jobRatio && jobLimit > 0){
-				if (leaderJob == job.name) {  //If the leader was assigned this job, remove one kitten.
+				if (leaderJob == job.name && this.leaderTrait) {  //If the leader was assigned this job, we need to assign one less kitten. leaderTrait checks if a leader is saved in the loadout
 					jobLimit--;
 				}
-				this.assignLoadoutLeader(kittens, leaderJob, setLeader);
 				if (jobLimit > 0) {
 					this.game.village.assignJob(this.game.village.getJob(job.name), jobLimit);
 					loadoutJobsSum -= job.value;
@@ -3593,13 +3608,6 @@ dojo.declare("com.nuclearunicorn.game.village.Loadout", null, {
 				leaderJob = jobsFiltered[0].name; //If the job limit is 0 (No Factories built) set another job
 			}
 		}
-
-		//Assign leader
-
-		if (!this.game.village.leader) {
-			this.assignLoadoutLeader(kittens, leaderJob, setLeader);
-		}
-
 
 		//Assign jobs
 
@@ -3739,7 +3747,7 @@ dojo.declare("com.nuclearunicorn.game.ui.LoadoutButtonController", com.nuclearun
 	},
 
 	clickHandler: function(model) {
-		model.options.loadout.setLoadout(true);
+		model.options.loadout.setLoadout();
 	},
 
 	getDescription: function(model) {


### PR DESCRIPTION
- The leader is assigned to the highest rank kitten with the saved trait and is assigned the saved job.
- Engineer jobs are assigned to the highest rank kittens.
- Fixed incorrect loadout behavior in edge cases
- The last loadout selected is highlighted (Couldn’t figure out using css to do it unfortunately)
- If Order of the Stars is researched, the leader will be assigned the priest job instead of the saved job.

Details

- In case the leader's job is limited (engineer with 0 factories) or has no saved job, they are assigned to a different job from the loadout if available.
- When assigning the leader, if there is no kitten with the saved trait, the highest rank kitten will be assigned as leader.
- Loadouts will only assign a leader if Civil service is researched


- The assignJob functions got an ‘optimize’ optional parameter (True by default and still requires register to be researched and having a leader) so that engineers can be assigned correctly.
