### PR TITLE
getResourcePerTickStack: hide space paragon if transferBonus is 0%

### DIFF
--- a/game.js
+++ b/game.js
@@ -3671,15 +3671,22 @@ dojo.declare("com.nuclearunicorn.game.ui.GamePage", null, {
 				type: "ratio",
 				value: spaceRatio - 1
 			});
-			spaceParagonSubStack.push({
-				name: $I("res.stack.spaceParagon"),
-				type: "ratio",
-				value: paragonSpaceProductionRatio - 1
-			});
+			var transferBonus = this.getEffect("prodTransferBonus");
+			// if transferBonus == 0, then it won't show up in the tooltip, but
+			// spaceParagon would still show up, which would make the tooltip
+			// look very misleading. so we manually hide the paragon line in
+			// this case; it's not useful anyways when transferBonus == 0.
+			if (transferBonus != 0) {
+				spaceParagonSubStack.push({
+					name: $I("res.stack.spaceParagon"),
+					type: "ratio",
+					value: paragonSpaceProductionRatio - 1
+				});
+			}
 			spaceParagonSubStack.push({
 				name: $I("res.stack.bonusTransf"),
 				type: "multiplier",
-				value: this.getEffect("prodTransferBonus")
+				value: transferBonus
 			});
 			perTickAutoprodSpaceStack.push(spaceParagonSubStack);
 		//<----


### PR DESCRIPTION
with 0 space elevators: before:
<img width="669" height="112" alt="image" src="https://github.com/user-attachments/assets/38254155-bf58-4308-9107-9ab27b1247f9" />

after:
<img width="699" height="95" alt="image" src="https://github.com/user-attachments/assets/f97798c9-9d89-4c00-98b2-4d3b6056fe5b" />


an alternative way to fix this would be to show multiplier lines even when value == 0. this would probably be a correct thing to do, but the transfer bonus is the only multiplier bonus in existence anyways. also currently multiplicative effects don't show enough decimal places so there's no way to tell between a 0% and 0.4% transfer bonus, but that is a bit of a tangent already.