### PR TITLE
Added `biolabBiofuelScienceMax` effect to `sharkRelationsBotanists`

### DIFF
--- a/game.js
+++ b/game.js
@@ -1514,9 +1514,9 @@ dojo.declare("com.nuclearunicorn.game.EffectsManager", null, {
 				title: $I("effectsMgr.statics.breweryPolicyManpowerRatio.title"),
 				type: "ratio"
 			},
-			"biolabBiofuelScienceMax": {
-				title: $I("effectsMgr.statics.biolabBiofuelScienceMax.title"),
-				type: "fixed"
+			"biolabBiofuelScienceMaxRatio": {
+				title: $I("effectsMgr.statics.biolabBiofuelScienceMaxRatio.title"),
+				type: "ratio"
 			},
 			"religionUpgradesDiscount":{
 				title: $I("effectsMgr.statics.religionUpgradesDiscount.title"),

--- a/game.js
+++ b/game.js
@@ -1514,6 +1514,10 @@ dojo.declare("com.nuclearunicorn.game.EffectsManager", null, {
 				title: $I("effectsMgr.statics.breweryPolicyManpowerRatio.title"),
 				type: "ratio"
 			},
+			"biolabBiofuelScienceMax": {
+				title: $I("effectsMgr.statics.biolabBiofuelScienceMax.title"),
+				type: "fixed"
+			},
 			"religionUpgradesDiscount":{
 				title: $I("effectsMgr.statics.religionUpgradesDiscount.title"),
 				type: "ratio"

--- a/js/buildings.js
+++ b/js/buildings.js
@@ -715,6 +715,7 @@ dojo.declare("classes.managers.BuildingsManager", com.nuclearunicorn.core.TabMan
 			for (var i in self.effects) {
 				self.effectsCalculated[i] = self.effects[i];
 			}
+			self.effects["scienceMax"] += self.getBiofuelScienceMax(self, game);
 
 		},
 		lackResConvert: false,
@@ -734,11 +735,30 @@ dojo.declare("classes.managers.BuildingsManager", com.nuclearunicorn.core.TabMan
 
 				if (self.val) {
 					self.effects["scienceRatio"] = 0.35 * (1 + self.on / self.val);
+					self.effects["scienceMax"] = self.effectsCalculated["scienceMax"] + self.getBiofuelScienceMax(self, game);
 				}
 
 				return amt;
 
 			}
+		},
+		getBiofuelScienceMax: function(self, game){
+			if (!game.workshop.get("biofuel").researched){
+				return 0;
+			}
+			var biofuelScience = game.getEffect("biolabBiofuelScienceMax");
+			if (!biofuelScience) {
+				return 0;
+			}
+			if (!self.on){
+				return 0;
+			}
+			biofuelScience *= self.on;
+			if (game.workshop.get("uplink").researched && game.bld.get("library").stage == 1){
+				var datacenterBonus = game.bld.get("library").val * game.getEffect("uplinkLabRatio");
+				biofuelScience *= (1 + datacenterBonus);
+			}
+			return biofuelScience;
 		},
 		flavor: $I("buildings.biolab.flavor")
 	},

--- a/js/buildings.js
+++ b/js/buildings.js
@@ -715,7 +715,7 @@ dojo.declare("classes.managers.BuildingsManager", com.nuclearunicorn.core.TabMan
 			for (var i in self.effects) {
 				self.effectsCalculated[i] = self.effects[i];
 			}
-			self.effects["scienceMax"] += self.getBiofuelScienceMax(self, game);
+			self.effects["scienceMax"] *= (1 + game.getEffect("biolabBiofuelScienceMaxRatio") * self.on);
 
 		},
 		lackResConvert: false,
@@ -735,30 +735,12 @@ dojo.declare("classes.managers.BuildingsManager", com.nuclearunicorn.core.TabMan
 
 				if (self.val) {
 					self.effects["scienceRatio"] = 0.35 * (1 + self.on / self.val);
-					self.effects["scienceMax"] = self.effectsCalculated["scienceMax"] + self.getBiofuelScienceMax(self, game);
+					self.effects["scienceMax"] = self.effectsCalculated["scienceMax"] * (1 + game.getEffect("biolabBiofuelScienceMaxRatio") * self.on);
 				}
 
 				return amt;
 
 			}
-		},
-		getBiofuelScienceMax: function(self, game){
-			if (!game.workshop.get("biofuel").researched){
-				return 0;
-			}
-			var biofuelScience = game.getEffect("biolabBiofuelScienceMax");
-			if (!biofuelScience) {
-				return 0;
-			}
-			if (!self.on){
-				return 0;
-			}
-			biofuelScience *= self.on;
-			if (game.workshop.get("uplink").researched && game.bld.get("library").stage == 1){
-				var datacenterBonus = game.bld.get("library").val * game.getEffect("uplinkLabRatio");
-				biofuelScience *= (1 + datacenterBonus);
-			}
-			return biofuelScience;
 		},
 		flavor: $I("buildings.biolab.flavor")
 	},

--- a/js/science.js
+++ b/js/science.js
@@ -1483,7 +1483,8 @@ dojo.declare("classes.managers.ScienceManager", com.nuclearunicorn.core.TabManag
             "refinePolicyRatio" : 0.25,
 			"biolabEnergyRatio" : -0.75,
 			"breweryPolicyManpowerRatio" : 0.01,
-			"woodRatio" : 0
+			"woodRatio" : 0,
+			"biolabBiofuelScienceMax": 25
         },
         unlocked: false,
         blocked: false,

--- a/js/science.js
+++ b/js/science.js
@@ -1484,7 +1484,7 @@ dojo.declare("classes.managers.ScienceManager", com.nuclearunicorn.core.TabManag
 			"biolabEnergyRatio" : -0.75,
 			"breweryPolicyManpowerRatio" : 0.01,
 			"woodRatio" : 0,
-			"biolabBiofuelScienceMax": 25
+			"biolabBiofuelScienceMaxRatio": 0.02
         },
         unlocked: false,
         blocked: false,

--- a/js/time.js
+++ b/js/time.js
@@ -1527,17 +1527,23 @@ dojo.declare("classes.ui.time.UseHeatBtnController", com.nuclearunicorn.game.ui.
 		var price = this.getPricesMultiple(model, amt);
 		var furnace = this.game.time.getCFU("blastFurnace");
 		if (furnace.heat < price.heat) {
-			callback(false /*itemBought*/, { reason: "cannot-afford" });
-			return true;
+            return {
+                itemBought: false,
+                reason: "cannot-afford"
+            };
 		}
 		if (!model.enabled) {
-			callback(false /*itemBought*/, { reason: "not-enabled" });
-			return true;
+            return {
+                itemBought: false,
+                reason: "not-enabled"
+            };
 		}
 		furnace.heat -= price.heat;
 		this.doShatter(model, amt);
-		callback(true /*itemBought*/, { reason: "paid-for" });
-		return true;
+		return {
+            itemBought: true /*itemBought*/,
+            reason: "paid-for"
+        };
 	},
 
 	doShatterAmt: function(model, amt) {

--- a/res/i18n/en.json
+++ b/res/i18n/en.json
@@ -398,7 +398,7 @@
     "effectsMgr.statics.barnRatio.title": "Barn expansion",
     "effectsMgr.statics.baseMetalMaxRatio.title": "Maximum base metal bonus",
     "effectsMgr.statics.beaconRelicsPerDay.title": "Relic production",
-    "effectsMgr.statics.biolabBiofuelScienceMax.title": "Biolab biofuel max science",
+    "effectsMgr.statics.biolabBiofuelScienceMaxRatio.title": "Biolab biofuel max science",
     "effectsMgr.statics.biolabEnergyRatio.title": "Bio Lab energy reduction",
     "effectsMgr.statics.biofuelRatio.title": "Bio Fuel bonus",
     "effectsMgr.statics.blackLibraryBonus.title": "Black Library bonus",

--- a/res/i18n/en.json
+++ b/res/i18n/en.json
@@ -398,6 +398,7 @@
     "effectsMgr.statics.barnRatio.title": "Barn expansion",
     "effectsMgr.statics.baseMetalMaxRatio.title": "Maximum base metal bonus",
     "effectsMgr.statics.beaconRelicsPerDay.title": "Relic production",
+    "effectsMgr.statics.biolabBiofuelScienceMax.title": "Biolab biofuel max science",
     "effectsMgr.statics.biolabEnergyRatio.title": "Bio Lab energy reduction",
     "effectsMgr.statics.biofuelRatio.title": "Bio Fuel bonus",
     "effectsMgr.statics.blackLibraryBonus.title": "Black Library bonus",


### PR DESCRIPTION
`biolabBiofuelScienceMax` effect makes biolabs that are doing biofuel processing also gain extra maximum science. This maximum is also multiplied by uplink bonus if it exists.