### PR TITLE
Show Religion tab immediately when faith first appears

### DIFF
--- a/js/religion.js
+++ b/js/religion.js
@@ -304,7 +304,13 @@ dojo.declare("classes.managers.ReligionManager", com.nuclearunicorn.core.TabMana
 	},
 	update: function(){
 		if (this.game.resPool.get("faith").value > 0 || this.game.challenges.isActive("atheism") && this.game.bld.get("ziggurat").val > 0){
-			this.game.religionTab.visible = true;
+			//Re-render when the tab first becomes visible (e.g. right after the first priest
+			// produces faith) so it appears immediately instead of on the player's next action.
+			//Guarded so we only render on the hidden->visible transition, not every tick.
+			if (!this.game.religionTab.visible){
+				this.game.religionTab.visible = true;
+				this.game.render();
+			}
 		}
 
 		//safe switch for a certain type of pesky bugs with conversion


### PR DESCRIPTION
ReligionManager.update() set religionTab.visible = true once faith > 0 (e.g. after the first priest), but never re-rendered, so the tab only appeared on the player's next action. Trigger a render on the hidden->visible transition (guarded so it doesn't render every tick), matching the pattern DiplomacyManager already uses for its tab.

(btw - I've started playing the game through again for a second time and I'm just PR'ing all these little bugs and QoL issues as I run into them, hence the trickle of updates....)

