### PR TITLE
clean up tooltips / resource highlights if their parent element disappears

### DIFF
--- a/core.js
+++ b/core.js
@@ -1565,7 +1565,7 @@ dojo.declare("com.nuclearunicorn.game.ui.ButtonModern", com.nuclearunicorn.game.
 		if (this.model.hasResourceHover) {
 			dojo.connect(this.domNode, "onmouseover", this,
 				dojo.hitch( this, function(){
-					this.game.setSelectedObject(this.getSelectedObject());
+					this.game.setSelectedObject(this.getSelectedObject(), this.domNode);
 				}));
 			dojo.connect(this.domNode, "onmouseout", this,
 				dojo.hitch( this, function(){
@@ -2650,6 +2650,8 @@ UIUtils = {
 			};
 			game.tooltipUpdateFunc();
 
+			game.tooltipOwnerDomNode = container;
+
 			var pos = $(container).offset();
 
 			// Compensate tooltip position for game container offset.
@@ -2680,8 +2682,7 @@ UIUtils = {
 		dojo.connect(container, "onmouseover", this, showTooltip);
 
 		dojo.connect(container, "onmouseout", this, function(){
-			game.tooltipUpdateFunc = null;
-			dojo.style(tooltip, "display", "none");
+			UIUtils.hideTooltip(game);
 		});
 		
 		dojo.connect(container, "onkeydown", this, function(e){
@@ -2695,5 +2696,10 @@ UIUtils = {
 		});
 
 		return htmlProvider;
+	},
+	hideTooltip: function(game){
+		game.tooltipUpdateFunc = null;
+		game.tooltipOwnerDomNode = null;
+		dojo.style(dojo.byId("tooltip"), "display", "none");
 	}
 };

--- a/game.js
+++ b/game.js
@@ -1927,12 +1927,15 @@ dojo.declare("com.nuclearunicorn.game.ui.GamePage", null, {
 	//current building selected in the Building tab by a mouse cursor, should affect resource table rendering
 	//TODO: move me to UI
 	selectedBuilding: null,
-	setSelectedObject: function(object) {
+	selectedBuildingDomNode: null,
+	setSelectedObject: function(object, domNode) {
 		this.selectedBuilding = object;
+		this.selectedBuildingDomNode = domNode;
 		this._publish("ui/update", this);
 	},
 	clearSelectedObject: function() {
 		this.selectedBuilding = null;
+		this.selectedBuildingDomNode = null;
 		this._publish("ui/update", this);
 	},
 

--- a/js/ui.js
+++ b/js/ui.js
@@ -628,6 +628,21 @@ dojo.declare("classes.ui.DesktopUI", classes.ui.UISystem, {
             this.game.tooltipUpdateFunc();
         }
 
+		// clear tooltips/highlights if their owning element doesn't exist
+		// anymore. if an element disappears (i.e. is removed from the DOM),
+		// its onmouseout handler does not fire, so the highlights/tooltips
+		// would get stuck.
+		if (this.game.tooltipOwnerDomNode) {
+			if (!document.contains(this.game.tooltipOwnerDomNode)) {
+				UIUtils.hideTooltip(this.game);
+			}
+		}
+		if (this.game.selectedBuildingDomNode) {
+			if (!document.contains(this.game.selectedBuildingDomNode)) {
+				this.game.clearSelectedObject();
+			}
+		}
+
         //wat
         /*React.render($r(WLeftPanel, {
             game: this.game


### PR DESCRIPTION
If an element is removed from the DOM, its onmouseout handler does not fire. Tooltips use onmouseout to hide the tooltip, so if the tooltip owner were to disappear, the tooltip would be stuck, at least until a different tooltip was shown.

The easiest way to trigger this is to mouse over a button with a tooltip and use a keyboard shortcut to switch to a different tab (one where there isn't a tooltip right under the cursor). (In fact, this is how I noticed this bug in the first place; it's somewhat annoying for me given how much I use the tab-switching shortcuts.)

The fix here tracks which DOM node requested the creation of this tooltip, and periodically checks if the node is still connected to the DOM, and hides the tooltip if that is not the case.

The exact same issue applies to the resource pane row highlighting feature, and I fixed that the same way.