### PR TITLE
Remove overflow hidden from theme_sleek.css

### DIFF
--- a/res/theme_sleek.css
+++ b/res/theme_sleek.css
@@ -167,7 +167,6 @@
     max-height: initial;
     min-width: initial;
     /*max-width: initial;*/
-    overflow: hidden;
     max-width: 1800px !important;
     margin: auto !important;
 }


### PR DESCRIPTION
Remove the cropping of the tooltip when hovering over the buildings in the queue.