### PR TITLE
don't save the save data to localstorage if it is from a failed import

### DIFF
--- a/game.js
+++ b/game.js
@@ -1999,6 +1999,11 @@ dojo.declare("com.nuclearunicorn.game.ui.GamePage", null, {
 	devMode: false,
 	mobileSaveOnPause: true,
 
+	// whether loading the save from localstorage failed.
+	// used to prevent overwriting the potentially-broken save data in
+	// localstorage with definitely-broken data from a partial save load.
+	currentSaveIsBroken: false,
+
 	//should this go to the res pool?
 	winterCatnipPerTick: 0,
 
@@ -2413,6 +2418,12 @@ dojo.declare("com.nuclearunicorn.game.ui.GamePage", null, {
 	},
 
 	save: function(){
+		if (this.currentSaveIsBroken) {
+			// if the save is broken, we return the original save that we tried to import.
+			// (unfortunately we need to parse it a little bit, since callers of save() expect the unserialized data...)
+			return this._parseLSSaveData(LCstorage["com.nuclearunicorn.kittengame.savedata"]);
+		}
+
 		this.ticksBeforeSave = this.autosaveFrequency;
 
 		var saveData = {
@@ -2560,6 +2571,7 @@ dojo.declare("com.nuclearunicorn.game.ui.GamePage", null, {
 	load: function(){
 		var data = LCstorage["com.nuclearunicorn.kittengame.savedata"];
 		this.resetState();
+		this.currentSaveIsBroken = false;
 		if (!data){
 			this.calculateAllEffects();
 			this.updateOptionsUI();
@@ -2607,6 +2619,7 @@ dojo.declare("com.nuclearunicorn.game.ui.GamePage", null, {
 
 			this.msg("Unable to load save data. Contact the devs and provide the faulty save file.", "important");
 			success = false;
+			this.currentSaveIsBroken = true;
 		}
 
 


### PR DESCRIPTION
If loading fails, the game is left in an inconsistent state, and most likely some part of the save file is not properly reflected in the game data. When saving, this caused parts of the original save file to be lost completely. Instead, it is better to keep the original save in localstorage, to avoid losing any information in it.

TODO: the error message on loading says to "contact the devs and provide the faulty save file". There is no way to access said faulty save file from the UI currently. Maybe the save export dialog could provide the data from localstorage in case of a failed load instead?