### PR TITLE
fix pact of purity effect being stuck after reload

### DIFF
--- a/js/religion.js
+++ b/js/religion.js
@@ -1008,11 +1008,10 @@ dojo.declare("classes.managers.ReligionManager", com.nuclearunicorn.core.TabMana
 				self.effectsPreDeficit[self.prefixEffectNames[counter]] = game.getEffect("pact" + self.prefixEffectNames[counter]) * transcendenceTierModifier;
 			}
 			self.effectsPreDeficit["deficitRecoveryRatio"] = game.getEffect("pactDeficitRecoveryRatio");
+
 			var pactBlackLibraryBoost = game.getEffect("pactBlackLibraryBoost") * transcendenceTierModifier;
-			if (pactBlackLibraryBoost) {
-				var unicornGraveyard = game.religion.getZU("unicornGraveyard");
-				self.effectsPreDeficit["blackLibraryBonus"] = pactBlackLibraryBoost * unicornGraveyard.effects["blackLibraryBonus"] * (1 + unicornGraveyard.on);
-			}
+			var unicornGraveyard = game.religion.getZU("unicornGraveyard");
+			self.effectsPreDeficit["blackLibraryBonus"] = pactBlackLibraryBoost * unicornGraveyard.effects["blackLibraryBonus"] * (1 + unicornGraveyard.on);
 		},
 		updateEffects: function(self, game){
 			if (!self.jammed){


### PR DESCRIPTION
repro steps:
* get some pacts of purity
* get to a state with 0 pacts of purity (by either undoing a pact purchase, or importing a save with 0 pacts)
* observe that black pyramids still have the black library bonus effect

the cause was that the effect wasn't set to 0 in the `else` branch of that `if` statement. I removed the `if` altogether, as it didn't really seem necessary.