### PR TITLE
Refactor game.karmaZebras / zebras.maxValue, fix stasis pods

### DIFF
--- a/game.js
+++ b/game.js
@@ -5256,10 +5256,6 @@ dojo.declare("com.nuclearunicorn.game.ui.GamePage", null, {
 		var karmaPrev = karmaRes.value;
 		karmaRes.value = karma;
 
-		if (this.karmaZebras){
-			this.resPool.get("zebras").maxValue = this.karmaZebras + 1;
-		}
-
 		//Recalculate some effects if karma amount has changed:
 		if (karma != karmaPrev) {
 			//Do not call game.upgrade here.  It'll have weird knock-on effects if we do that.

--- a/js/buildings.js
+++ b/js/buildings.js
@@ -2236,7 +2236,7 @@ dojo.declare("classes.managers.BuildingsManager", com.nuclearunicorn.core.TabMan
 		priceRatio: 1.25,
 		zebraRequired: 1,
 		effects: {
-			"zebraMax": 1,
+			"zebrasMax": 1,
 		},
 	},
 	{

--- a/js/calendar.js
+++ b/js/calendar.js
@@ -630,7 +630,7 @@ dojo.declare("com.nuclearunicorn.game.Calendar", null, {
 			if (!zebras.value && archery.researched){
 				this.game.resPool.addResEvent("zebras", 1);
 				this.game.msg($I("calendar.msg.zebra.hunter"));
-			} else if ( zebras.value > 0 && zebras.value <= this.game.karmaZebras && this.game.karmaZebras > 0){
+			} else if ( zebras.value > 0 && zebras.value < zebras.maxValue){
 				var chanceModifier = (this.game.workshop.getZebraUpgrade("darkBrew").researched && this.festivalDays)?
 				2 + this.game.getEffect("festivalArrivalRatio") : 1; //bigger chance for zebras to arive after darkBrew is researched
 				if (this.game.rand(100000) <= 500 * chanceModifier){
@@ -642,10 +642,10 @@ dojo.declare("com.nuclearunicorn.game.Calendar", null, {
 		} else {
 			var zTreshold = 0;
 			if (this.game.prestige.getPerk("zebraDiplomacy").researched){
-				zTreshold = Math.floor(0.10 * (this.game.karmaZebras + 1));   //5 - 10% of hunters will stay
+				zTreshold = Math.floor(0.10 * zebras.maxValue);   //5 - 10% of hunters will stay
 			}
 			if (this.game.prestige.getPerk("zebraCovenant").researched){
-				zTreshold = Math.floor(0.50 * (this.game.karmaZebras + 1));   //5 - 50% of hunters will stay
+				zTreshold = Math.floor(0.50 * zebras.maxValue);   //5 - 50% of hunters will stay
 			}
 			if (zebras.value > zTreshold ){
 				this.game.msg( zebras.value > 1 ?
@@ -810,7 +810,7 @@ dojo.declare("com.nuclearunicorn.game.Calendar", null, {
 				totalNumberOfEvents += numberEvents;
 			}
 
-			if ( zebras.value > 0 && zebras.value <= this.game.karmaZebras && this.game.karmaZebras > 0){
+			if ( zebras.value > 0 && zebras.value < zebras.maxValue){
 				numberEvents = Math.round(daysOffset * 500 / 100000);
 				this.game.resPool.addResEvent("zebras", numberEvents);
 				totalNumberOfEvents += numberEvents;

--- a/js/resources.js
+++ b/js/resources.js
@@ -784,6 +784,10 @@ dojo.declare("classes.managers.ResourceManager", com.nuclearunicorn.core.TabMana
 
 		var maxValue = game.getEffect(res.name + "Max") || 0;
 
+		if (res.name == "zebras") {
+			maxValue += (game.karmaZebras || 0) + 1;
+		}
+
 		maxValue = Math.min(this.addResMaxRatios(res, maxValue), Number.MAX_VALUE);
 		
 		var challengeEffect = this.game.getEffect(res.name + "MaxChallenge");
@@ -901,7 +905,7 @@ dojo.declare("classes.managers.ResourceManager", com.nuclearunicorn.core.TabMana
 	 * Called in tooltips for more accurate per-building resMax increases
 	 */
 	addResMaxRatios: function(res, maxValue) {
-		if (res.name == "temporalFlux") {
+		if (res.name == "temporalFlux" || res.name == "zebras") {
 			return maxValue;
 		}
 


### PR DESCRIPTION
Change most places that referenced game.karmaZebras to instead use the zebras resource's maxValue. Also changed how zebras' maxValue is calculated. This makes stasis pod's effect work properly.