### PR TITLE
Price refactor part 1

### DIFF
--- a/core.js
+++ b/core.js
@@ -2098,8 +2098,9 @@ dojo.declare("com.nuclearunicorn.game.ui.BuildingStackableBtnController", Buildi
 			var resPriceDiscount = this.game.getEffect(meta.prices[i].name + "CostReduction");
 			resPriceDiscount = this.game.getLimitedDR(resPriceDiscount, 1);
 			var resPriceModifier = 1 - resPriceDiscount;
+			var resourcePriceRatio = meta.prices[i].priceRatio || ratio;
             prices.push({
-            	val: meta.prices[i].val * Math.pow(ratio, meta.val) * resPriceModifier * priceModifier,
+            	val: meta.prices[i].val * Math.pow(resourcePriceRatio, meta.val) * resPriceModifier * priceModifier,
             	name: meta.prices[i].name
 			});
         }

--- a/core.js
+++ b/core.js
@@ -2094,13 +2094,25 @@ dojo.declare("com.nuclearunicorn.game.ui.BuildingStackableBtnController", Buildi
 		var pricesDiscount = this.game.getLimitedDR((this.game.getEffect(meta.name + "CostReduction")), 1);
 		var priceModifier = 1 - pricesDiscount;
 
+		if (meta.priceRules) {
+			for (var i = 0; i < meta.prices.length; i++){
+				var resPriceDiscount = this.game.getEffect(meta.prices[i].name + "CostReduction");
+				resPriceDiscount = this.game.getLimitedDR(resPriceDiscount, 1);
+				var resPriceModifier = 1 - resPriceDiscount;
+				var resourcePriceRatio = meta.prices[i].priceRatio || ratio;
+				prices.push({
+					val: meta.prices[i].val * Math.pow(resourcePriceRatio, meta.val) * resPriceModifier * priceModifier,
+					name: meta.prices[i].name
+				});
+        	}
+			return prices;
+		}
         for (var i = 0; i < meta.prices.length; i++){
 			var resPriceDiscount = this.game.getEffect(meta.prices[i].name + "CostReduction");
 			resPriceDiscount = this.game.getLimitedDR(resPriceDiscount, 1);
 			var resPriceModifier = 1 - resPriceDiscount;
-			var resourcePriceRatio = meta.prices[i].priceRatio || ratio;
             prices.push({
-            	val: meta.prices[i].val * Math.pow(resourcePriceRatio, meta.val) * resPriceModifier * priceModifier,
+            	val: meta.prices[i].val * Math.pow(ratio, meta.val) * resPriceModifier * priceModifier,
             	name: meta.prices[i].name
 			});
         }

--- a/js/buildings.js
+++ b/js/buildings.js
@@ -858,6 +858,7 @@ dojo.declare("classes.managers.BuildingsManager", com.nuclearunicorn.core.TabMan
 	
 				stageMeta.effects = game.resPool.addBarnWarehouseRatio(effects);
             } else if (self.stage == 1){
+			stageMeta.priceRules = true;
 			var effects = {
 					"moonBaseStorageBonus": 0.0085,
 					"planetCrackerStorageBonus": 0.0085,
@@ -2427,13 +2428,29 @@ dojo.declare("classes.managers.BuildingsManager", com.nuclearunicorn.core.TabMan
 		var pricesDiscount = this.game.getLimitedDR((this.game.getEffect(bldName + "CostReduction")), 1);
 		var priceModifier = 1 - pricesDiscount;
 		var fakeBought = this.game.getEffect(bldName + "FakeBought") + additionalBought;
-
-		for (var i = 0; i < bldPrices.length; i++) {
-			var resPriceDiscount = this.game.getLimitedDR(this.game.getEffect(bldPrices[i].name + "CostReduction"), 1);
-			var resPriceModifier = 1 - resPriceDiscount;
-			var cost = bldPrices[i].val * Math.pow(ratio, bldVal + fakeBought) * priceModifier * resPriceModifier;
-			if (bldPrices[i].multPriceRatio) {
-				cost *= Math.pow(bldPrices[i].multPriceRatio, bldVal + fakeBought)
+		
+		if (bld.get("priceRules")){
+			for (var i = 0; i < bldPrices.length; i++) {
+				var resPriceDiscount = this.game.getLimitedDR(this.game.getEffect(bldPrices[i].name + "CostReduction"), 1);
+				var resPriceModifier = 1 - resPriceDiscount;
+				var cost = bldPrices[i].val * Math.pow(ratio, bldVal + fakeBought) * priceModifier * resPriceModifier;
+				if (bldPrices[i].multPriceRatio) {
+					cost *= Math.pow(bldPrices[i].multPriceRatio, bldVal + fakeBought)
+				}
+				prices.push({
+					val: cost,
+					name: bldPrices[i].name
+				});
+			}
+		} else {
+			for (var i = 0; i < bldPrices.length; i++) {
+				var resPriceDiscount = this.game.getLimitedDR(this.game.getEffect(bldPrices[i].name + "CostReduction"), 1);
+				var resPriceModifier = 1 - resPriceDiscount;
+				var cost = bldPrices[i].val * Math.pow(ratio, bldVal + fakeBought) * priceModifier * resPriceModifier;
+				prices.push({
+					val: cost,
+					name: bldPrices[i].name
+				});
 			}
 			prices.push({
 				val: cost,

--- a/js/buildings.js
+++ b/js/buildings.js
@@ -821,6 +821,9 @@ dojo.declare("classes.managers.BuildingsManager", com.nuclearunicorn.core.TabMan
 					{ name: "eludium", val: 500 },
 					{ name: "kerosene", val: 1000 },
 					{ name: "blueprint", val: 500 },
+					/**
+					* Spaceport uses  a much steper price ratio for starcharts to be a dedicated starchart sinker
+					*/
 					{ name: "starchart", val: 100000, priceRatios: [1.35] },
 				],
 				priceRatio: 1.15,
@@ -2508,17 +2511,6 @@ dojo.declare("classes.managers.BuildingsManager", com.nuclearunicorn.core.TabMan
 				//Else, if the weight is under 100, we don't add anything to the price.
 			}
 		}
-		/**
-		 * Spaceport will use a much steper price ratio for starcharts to be a dedicated starchart sinker
-		 */
-		if (bldName == "warehouse" && bld.get("stage") == 1){
-			for (var i = 0; i < prices.length; i++) {
-				if (prices[i].name == "starchart"){
-					prices[i].val = prices[i].val * Math.pow(1.35, bldVal);
-				}
-			}
-		}
-
 		return prices;
 	 },
 

--- a/js/buildings.js
+++ b/js/buildings.js
@@ -821,7 +821,7 @@ dojo.declare("classes.managers.BuildingsManager", com.nuclearunicorn.core.TabMan
 					{ name: "eludium", val: 500 },
 					{ name: "kerosene", val: 1000 },
 					{ name: "blueprint", val: 500 },
-					{ name: "starchart", val: 100000 },
+					{ name: "starchart", val: 100000, priceRatios: [1.35] },
 				],
 				priceRatio: 1.15,
 				effects: {
@@ -2428,8 +2428,14 @@ dojo.declare("classes.managers.BuildingsManager", com.nuclearunicorn.core.TabMan
 		for (var i = 0; i < bldPrices.length; i++) {
 			var resPriceDiscount = this.game.getLimitedDR(this.game.getEffect(bldPrices[i].name + "CostReduction"), 1);
 			var resPriceModifier = 1 - resPriceDiscount;
+			var cost = bldPrices[i].val * Math.pow(ratio, bldVal + fakeBought) * priceModifier * resPriceModifier;
+			if (bldPrices[i].priceRatios) {
+				for (var localRatio in bldPrices[i].priceRatios){
+					cost *= Math.pow(bldPrices[i].priceRatios, bldVal + fakeBought)
+				}
+			}
 			prices.push({
-				val: bldPrices[i].val * Math.pow(ratio, bldVal + fakeBought) * priceModifier * resPriceModifier,
+				val: cost,
 				name: bldPrices[i].name
 			});
 		}

--- a/js/buildings.js
+++ b/js/buildings.js
@@ -2452,10 +2452,6 @@ dojo.declare("classes.managers.BuildingsManager", com.nuclearunicorn.core.TabMan
 					name: bldPrices[i].name
 				});
 			}
-			prices.push({
-				val: cost,
-				name: bldPrices[i].name
-			});
 		}
 
 		if (this.game.challenges.isActive("blackSky")

--- a/js/buildings.js
+++ b/js/buildings.js
@@ -824,7 +824,7 @@ dojo.declare("classes.managers.BuildingsManager", com.nuclearunicorn.core.TabMan
 					/**
 					* Spaceport uses  a much steper price ratio for starcharts to be a dedicated starchart sinker
 					*/
-					{ name: "starchart", val: 100000, priceRatios: [1.35] },
+					{ name: "starchart", val: 100000, multPriceRatio: 1.35 },
 				],
 				priceRatio: 1.15,
 				effects: {
@@ -2432,10 +2432,8 @@ dojo.declare("classes.managers.BuildingsManager", com.nuclearunicorn.core.TabMan
 			var resPriceDiscount = this.game.getLimitedDR(this.game.getEffect(bldPrices[i].name + "CostReduction"), 1);
 			var resPriceModifier = 1 - resPriceDiscount;
 			var cost = bldPrices[i].val * Math.pow(ratio, bldVal + fakeBought) * priceModifier * resPriceModifier;
-			if (bldPrices[i].priceRatios) {
-				for (var localRatio in bldPrices[i].priceRatios){
-					cost *= Math.pow(bldPrices[i].priceRatios, bldVal + fakeBought)
-				}
+			if (bldPrices[i].multPriceRatio) {
+				cost *= Math.pow(bldPrices[i].multPriceRatio, bldVal + fakeBought)
 			}
 			prices.push({
 				val: cost,

--- a/js/buildings.js
+++ b/js/buildings.js
@@ -2428,7 +2428,21 @@ dojo.declare("classes.managers.BuildingsManager", com.nuclearunicorn.core.TabMan
 		var pricesDiscount = this.game.getLimitedDR((this.game.getEffect(bldName + "CostReduction")), 1);
 		var priceModifier = 1 - pricesDiscount;
 		var fakeBought = this.game.getEffect(bldName + "FakeBought") + additionalBought;
-		
+
+		// The most simple case of all: priceRules tag is not true and we aren't in unicornTears challenge! Allows early escape patch
+		// TODO: code duplication might be solvable!
+		if (!bld.get("priceRules") && !this.game.challenges.isActive("unicornTears")){
+			for (var i = 0; i < bldPrices.length; i++) {
+				var resPriceDiscount = this.game.getLimitedDR(this.game.getEffect(bldPrices[i].name + "CostReduction"), 1);
+				var resPriceModifier = 1 - resPriceDiscount;
+				var cost = bldPrices[i].val * Math.pow(ratio, bldVal + fakeBought) * priceModifier * resPriceModifier;
+				prices.push({
+					val: cost,
+					name: bldPrices[i].name
+				});
+			}
+			return prices;
+		}
 		if (bld.get("priceRules")){
 			for (var i = 0; i < bldPrices.length; i++) {
 				var resPriceDiscount = this.game.getLimitedDR(this.game.getEffect(bldPrices[i].name + "CostReduction"), 1);
@@ -2442,6 +2456,35 @@ dojo.declare("classes.managers.BuildingsManager", com.nuclearunicorn.core.TabMan
 					name: bldPrices[i].name
 				});
 			}
+
+			if (this.game.challenges.isActive("blackSky")
+		 	&& bldName == "calciner"
+		 	&& bldVal == 0) {
+				for (var i = 0; i < prices.length; i++) {
+					prices[i].val *= prices[i].name == "titanium" ? 0 : 11;
+				}
+			}
+			if (this.game.challenges.isActive("pacifism")
+			&& bldName == "steamworks"
+			&& bldVal == 0) {
+				for (var i = 0; i < prices.length; i++) {
+					if (prices[i].name == "blueprint"){
+						prices[i].val = this.game.challenges.getChallenge("pacifism").on * 5 + 1;
+					}
+				}
+			}
+
+			if (this.game.challenges.isActive("postApocalypse")
+			&& bldName == "field"
+			&& this.getPollutionLevel() >= 5
+			&& bldVal >= Math.max(95 - this.game.time.getVSU("usedCryochambers").val - this.getPollutionLevel(), 7 + (this.game.ironWill? 8 : 0)) ) {
+				var builtWithUnobtanium = Math.max(bldVal + this.game.time.getVSU("usedCryochambers").val - 100, 0);
+				prices.push({val: 15 * Math.pow(ratio, builtWithUnobtanium),
+						name : "unobtainium",
+						isTemporary: true //can't exploit buy manipulating pollution in postApocalypse
+				});
+			}
+		
 		} else {
 			for (var i = 0; i < bldPrices.length; i++) {
 				var resPriceDiscount = this.game.getLimitedDR(this.game.getEffect(bldPrices[i].name + "CostReduction"), 1);
@@ -2454,77 +2497,56 @@ dojo.declare("classes.managers.BuildingsManager", com.nuclearunicorn.core.TabMan
 			}
 		}
 
-		if (this.game.challenges.isActive("blackSky")
-		 && bldName == "calciner"
-		 && bldVal == 0) {
-			for (var i = 0; i < prices.length; i++) {
-				prices[i].val *= prices[i].name == "titanium" ? 0 : 11;
-			}
-		}
-
-		if (this.game.challenges.isActive("pacifism")
-		 && bldName == "steamworks"
-		 && bldVal == 0) {
-			for (var i = 0; i < prices.length; i++) {
-				if (prices[i].name == "blueprint"){
-					prices[i].val = this.game.challenges.getChallenge("pacifism").on * 5 + 1;
-				}
-			}
-		}
-		if (this.game.challenges.isActive("postApocalypse")
-		&& bldName == "field"
-		&& this.getPollutionLevel() >= 5
-		&& bldVal >= Math.max(95 - this.game.time.getVSU("usedCryochambers").val - this.getPollutionLevel(), 7 + (this.game.ironWill? 8 : 0)) ) {
-			var builtWithUnobtanium = Math.max(bldVal + this.game.time.getVSU("usedCryochambers").val - 100, 0);
-			prices.push({val: 15 * Math.pow(ratio, builtWithUnobtanium),
-						name : "unobtainium",
-						isTemporary: true //can't exploit buy manipulating pollution in postApocalypse
-					});
-		}
+		// unicornTears can't really use the priceRules because it affects basically everything!
+		// But this refactor limited the number of checks for other challenge modifying prices and such
 		if (this.game.challenges.isActive("unicornTears")
 		 && bldVal > 0 /*For the purposes of Challenge compatibility, the first one will always have its price unmodified.*/) {
-			//In the Unicorn Tears Challenge, we give each Bonfire building a price of unicorns, unicorn tears, or alicorns.
-			if (bldName == "warehouse" && bld.get("stage") == 0 /*Affects Warehouses but not Spaceports*/) {
-				//I don't like having these special cases, but I want to avoid the player getting stuck.
-				prices.push({ name: "unicorns",
-					val: 2 * bldVal * priceModifier, //Linear (not exponential) scaling
-					isTemporary: true
-				});
-			} else if (bldName == "harbor") {
-				//I don't like having these special cases, but I want to avoid the player getting stuck.
-				prices.push({ name: "tears",
-					val: 2 * bldVal * priceModifier, //Linear (not exponential) scaling
-					isTemporary: true
-				});
-			} else {
-				//We use the base price of a building (not affected by policies that reduce resource prices) to calculate the weight:
-				var weight = this.game.challenges.getChallenge("unicornTears").sumPricesWeighted(bldPrices);
-				if (weight > 0) {
-					//We use a price ratio determined by the Unicorn Tears Challenge.
-					weight *= Math.pow(this.game.getEffect("bonfireTearsPriceRatioChallenge"), bldVal - 1);
-				}
-				if (weight > 1e9) {
-					prices.push({ name: "alicorn",
-						val: (Math.log(weight) - 19.7232) * priceModifier, //With a weight of exactly 1e9, this is just a smidge over 1
-						isTemporary: true
-					});
-				} else if (weight > 100000) {
-					prices.push({ name: "tears",
-						val: weight / 100000 * priceModifier,
-						isTemporary: true
-					});
-				} else if (weight >= 100) {
-					prices.push({ name: "unicorns",
-						val: weight / 100 * priceModifier,
-						isTemporary: true
-					});
-				}
-				//Else, if the weight is under 100, we don't add anything to the price.
-			}
+			prices = this.applyUnicornTearsPrices(bld, bldName, bldVal, priceModifier, bldPrices, prices);
 		}
 		return prices;
 	 },
 
+	applyUnicornTearsPrices: function(bld, bldName, bldVal, priceModifier, bldPrices, prices){
+		//In the Unicorn Tears Challenge, we give each Bonfire building a price of unicorns, unicorn tears, or alicorns.
+		if (bldName == "warehouse" && bld.get("stage") == 0 /*Affects Warehouses but not Spaceports*/) {
+			//I don't like having these special cases, but I want to avoid the player getting stuck.
+			prices.push({ name: "unicorns",
+				val: 2 * bldVal * priceModifier, //Linear (not exponential) scaling
+				isTemporary: true
+			});
+		} else if (bldName == "harbor") {
+			//I don't like having these special cases, but I want to avoid the player getting stuck.
+			prices.push({ name: "tears",
+				val: 2 * bldVal * priceModifier, //Linear (not exponential) scaling
+				isTemporary: true
+			});
+		} else {
+			//We use the base price of a building (not affected by policies that reduce resource prices) to calculate the weight:
+			var weight = this.game.challenges.getChallenge("unicornTears").sumPricesWeighted(bldPrices);
+			if (weight > 0) {
+				//We use a price ratio determined by the Unicorn Tears Challenge.
+				weight *= Math.pow(this.game.getEffect("bonfireTearsPriceRatioChallenge"), bldVal - 1);
+			}
+			if (weight > 1e9) {
+				prices.push({ name: "alicorn",
+					val: (Math.log(weight) - 19.7232) * priceModifier, //With a weight of exactly 1e9, this is just a smidge over 1
+					isTemporary: true
+				});
+			} else if (weight > 100000) {
+				prices.push({ name: "tears",
+					val: weight / 100000 * priceModifier,
+					isTemporary: true
+				});
+			} else if (weight >= 100) {
+				prices.push({ name: "unicorns",
+					val: weight / 100 * priceModifier,
+					isTemporary: true
+				});
+			}
+			//Else, if the weight is under 100, we don't add anything to the price.
+		}
+		return prices;
+	},
 
 	calculatePollutionEffects: function(){
 		var POL_LBASE = this.getPollutionLevelBase();

--- a/js/buildings.js
+++ b/js/buildings.js
@@ -2435,7 +2435,7 @@ dojo.declare("classes.managers.BuildingsManager", com.nuclearunicorn.core.TabMan
 				var resPriceModifier = 1 - resPriceDiscount;
 				var cost = bldPrices[i].val * Math.pow(ratio, bldVal + fakeBought) * priceModifier * resPriceModifier;
 				if (bldPrices[i].multPriceRatio) {
-					cost *= Math.pow(bldPrices[i].multPriceRatio, bldVal + fakeBought)
+					cost *= Math.pow(bldPrices[i].multPriceRatio, bldVal + fakeBought);
 				}
 				prices.push({
 					val: cost,

--- a/js/challenges.js
+++ b/js/challenges.js
@@ -243,9 +243,11 @@ dojo.declare("classes.managers.ChallengesManager", com.nuclearunicorn.core.TabMa
             if (self.active) {
                 self.effects["corruptionBoostRatioChallenge"] = 0;
                 self.effects["bskSattelitePenalty"] = 0.1 * (game.ironWill ? 0 : (self.on || 0));
+				game.bld.getBuildingExt("calciner").meta.priceRules = true;
             } else {
 				self.effects["corruptionBoostRatioChallenge"] = 0.1;
 				self.effects["bskSattelitePenalty"] = 0;
+				game.bld.getBuildingExt("calciner").meta.priceRules = undefined;
 			}
 			game.upgrade(self.upgrades);
         },
@@ -282,6 +284,7 @@ dojo.declare("classes.managers.ChallengesManager", com.nuclearunicorn.core.TabMa
 				self.effects["embassyFakeBought"] = 1;
 				self.effects["steamworksFakeBought"] = Math.floor(1.5 * self.on || 1)/ (self.on || 1);
                 self.effects["tradeKnowledgeRatio"] = 0;
+				game.bld.getBuildingExt("steamworks").meta.priceRules = true;
             } else {
 				self.effects["alicornPerTickRatio"] = 0.1;
 				self.effects["tradeKnowledge"] = 1;
@@ -290,6 +293,7 @@ dojo.declare("classes.managers.ChallengesManager", com.nuclearunicorn.core.TabMa
 				self.effects["embassyFakeBought"] = 0;
 				self.effects["steamworksFakeBought"] = 0;
                 self.effects["tradeKnowledgeRatio"] = self.getTradeBonusEffect(game);
+				game.bld.getBuildingExt("steamworks").meta.priceRules = undefined;
 			}
 			game.upgrade(self.upgrades); //this is a hack, might need to think of a better sollution later
 		},
@@ -464,9 +468,11 @@ dojo.declare("classes.managers.ChallengesManager", com.nuclearunicorn.core.TabMa
 			if (self.active){
 				self.effects["arrivalSlowdown"] = 10;
 				self.effects["cryochamberSupport"] = 1; //this is a quick fix for cryochamber cap when resetting into PA; does not make PA easier so it's ok
+				game.bld.getBuildingExt("field").meta.priceRules = true;
 			} else {
 				self.effects["arrivalSlowdown"] = 0;
 				self.effects["cryochamberSupport"] = 1;
+				game.bld.getBuildingExt("field").meta.priceRules = undefined;
 			}
 		},
 		findRuins: function (self, game) {

--- a/js/religion.js
+++ b/js/religion.js
@@ -1464,10 +1464,10 @@ dojo.declare("classes.managers.ReligionManager", com.nuclearunicorn.core.TabMana
 		prices: [
 			{ name : "relic", val: 230000},
 			{ name : "void", val: 29000},
-			{ name : "paragon", val: 8}
+			{ name : "paragon", val: 8, priceRatio: 2}
 		],
 		tier: 27,
-		priceRatio: 2,
+		priceRatio: 1.75,
 		effects: {
 			"milleninumParagon": 1
 		},

--- a/js/religion.js
+++ b/js/religion.js
@@ -1466,6 +1466,7 @@ dojo.declare("classes.managers.ReligionManager", com.nuclearunicorn.core.TabMana
 			{ name : "void", val: 29000},
 			{ name : "paragon", val: 8, priceRatio: 2}
 		],
+		priceRules: true,
 		tier: 27,
 		priceRatio: 1.75,
 		effects: {


### PR DESCRIPTION
1. children of `com.nuclearunicorn.game.ui.BuildingStackableBtnController` can now use `meta.prices[i].priceRatio` instead of default stackable price ratio if it exists. This is used by Black Paracosm having a general 1.75 price ratio but 2 for the paragon cost
2. `meta.prices[i].multPriceRatio` was added to bonefire stackables. This will make the `multPriceRatio` apply after the building price ratio, recreating spaceport starcharts cost behavior without having to special case it
3. Both of the above require a `priceRules` flag to be true to check for those behaviors. It is quite likely that duplication of code could be reduced but I'll try to make all the edge case price code stackables to use the `priceRules` flag first