### PR TITLE
Energy Rifts UI Stuff

### DIFF
--- a/game.js
+++ b/game.js
@@ -2576,10 +2576,7 @@ dojo.declare("com.nuclearunicorn.game.ui.GamePage", null, {
 		this.ticksBeforeSave = this.autosaveFrequency;
 
 		var saveData = {
-			saveVersion: this.saveVersion,
-			resources: this.resPool.filterMetadata(
-				this.resPool.resources, ["name", "value", "unlocked", "isHidden", "isHiddenFromCrafting"]
-			)
+			saveVersion: this.saveVersion
 		};
 
 		this.server.save(saveData);
@@ -2589,9 +2586,9 @@ dojo.declare("com.nuclearunicorn.game.ui.GamePage", null, {
 		this.console.save(saveData);
 		this.telemetry.save(saveData);
 
-        for (var i in this.managers){
-            this.managers[i].save(saveData);
-        }
+		for (var i in this.managers){
+			this.managers[i].save(saveData);
+		}
 
 		saveData.game = {
 			isCMBREnabled: this.isCMBREnabled,

--- a/game.js
+++ b/game.js
@@ -2822,6 +2822,7 @@ dojo.declare("com.nuclearunicorn.game.ui.GamePage", null, {
 		}
 		// Calculate effects (needs to be done after all managers and save data are loaded)
 		this.calculateAllEffects();
+		this.resPool.updateMaxValueAll();
 		//------------------------------------
 
 		this.villageTab.visible = this.villageTab.evaluateLocks();

--- a/js/buildings.js
+++ b/js/buildings.js
@@ -3388,6 +3388,13 @@ dojo.declare("com.nuclearunicorn.game.ui.tab.BuildingsModern", com.nuclearunicor
 
 		var groups = dojo.clone(this.game.bld.buildingGroups, true);
 
+		//This is a semi-hacky way to modify buildingGroups at runtime.
+		//We're technically modifying a deep copy of it.
+		if (this.game.workshop.get("energyRifts").researched) {
+			var storageGroup = this.game.bld.getMeta("storage", groups);
+			storageGroup.buildings.push("accelerator");
+		}
+
 		//non-group filters
 		if (this.game.ironWill && this.game.libraryTab.visible){
 			groups.unshift({

--- a/js/buildings.js
+++ b/js/buildings.js
@@ -1634,6 +1634,9 @@ dojo.declare("classes.managers.BuildingsManager", com.nuclearunicorn.core.TabMan
 			var capRatio = 0;
 			if (game.workshop.get("energyRifts").researched){
 				capRatio = (1 + game.getEffect("acceleratorRatio"));
+				self.description = $I("buildings.accelerator.desc") + "<br>" + $I("buildings.accelerator.desc2");
+			} else {
+				self.description = $I("buildings.accelerator.desc");
 			}
 
 			self.effects["catnipMax"]   = 30000 * capRatio;

--- a/js/buildings.js
+++ b/js/buildings.js
@@ -203,6 +203,7 @@ dojo.declare("classes.managers.BuildingsManager", com.nuclearunicorn.core.TabMan
 		}
 	},
 
+	//Use getBuildingGroups if you want a metadata array which is updated based on game-state.
 	buildingGroups: [{
 		name: "food",
 		title: $I("buildings.group.food"),
@@ -2365,6 +2366,65 @@ dojo.declare("classes.managers.BuildingsManager", com.nuclearunicorn.core.TabMan
             }
         }
     },
+
+	/**
+	 * Returns a deep copy of all building groups.
+	 * @param {boolean} includeNonGroupFilters If enabled, includes extra things like "IW", "Togglable", "All", etc.
+	 * 			The UI code treats these as special building groups for the sake of player convenience.
+	 * @return An array of buildingGroup objects, which have 3 fields: name (string), title (string), buildings (array of strings)
+	 */
+	getBuildingGroups: function(includeNonGroupFilters) {
+		var game = this.game;
+		var groupsArr = [];
+
+		//See renderActiveGroup for how these are handled, since their buildings arrays are empty.
+		if (includeNonGroupFilters) {
+			groupsArr.push({
+				name: "all",
+				title: $I("ui.filter.all"),
+				buildings: []
+			});
+			groupsArr.push({
+				name: "available",
+				title: $I("ui.filter.available"),
+				buildings: []
+			});
+			groupsArr.push({
+				name: "allEnabled",
+				title: $I("ui.filter.enabled"),
+				buildings: []
+			});
+			groupsArr.push({
+				name: "togglable",
+				title: $I("ui.filter.togglable"),
+				buildings: []
+			});
+
+			if (game.ironWill && game.libraryTab.visible) {
+				groupsArr.push({
+					name: "iw",
+					title: $I("ui.filter.ironWill"),
+					buildings: []
+				});
+			}
+		}
+
+		//Now, deep-copy this.buildingGroups into groupsArr:
+		this.buildingGroups.forEach(function(bldGroup) {
+			groupsArr.push({
+				name: bldGroup.name,
+				title: bldGroup.title,
+				buildings: bldGroup.buildings.slice() //Shallow-copy array
+			});
+		});
+
+		//Apply modifications at runtime such as upgrades which give buildings dual purpose:
+		if (game.workshop.get("energyRifts").researched) {
+			var storageGroup = this.getMeta("storage", groupsArr);
+			storageGroup.buildings.push("accelerator");
+		}
+		return groupsArr;
+	},
 	getAutoProductionRatio: function() {
 		var autoProdRatio = 1;
 
@@ -3389,43 +3449,7 @@ dojo.declare("com.nuclearunicorn.game.ui.tab.BuildingsModern", com.nuclearunicor
 			className: "bldTopContainer"
 		}, content);
 
-		var groups = dojo.clone(this.game.bld.buildingGroups, true);
-
-		//This is a semi-hacky way to modify buildingGroups at runtime.
-		//We're technically modifying a deep copy of it.
-		if (this.game.workshop.get("energyRifts").researched) {
-			var storageGroup = this.game.bld.getMeta("storage", groups);
-			storageGroup.buildings.push("accelerator");
-		}
-
-		//non-group filters
-		if (this.game.ironWill && this.game.libraryTab.visible){
-			groups.unshift({
-				name: "iw",
-				title: "IW",
-				buildings: []
-			});
-		}
-		groups.unshift({
-			name: "togglable",
-			title: $I("ui.filter.togglable"),
-			buildings: []
-		});
-		groups.unshift({
-			name: "allEnabled",
-			title: $I("ui.filter.enabled"),
-			buildings: []
-		});
-		groups.unshift({
-			name: "available",
-			title: $I("ui.filter.available"),
-			buildings: []
-		});
-		groups.unshift({
-			name: "all",
-			title: $I("ui.filter.all"),
-			buildings: []
-		});
+		var groups = this.game.bld.getBuildingGroups(true /*includeNonGroupFilters*/);
 
 		if (!this.activeGroup){
 			this.activeGroup = groups[0].name;

--- a/js/resources.js
+++ b/js/resources.js
@@ -989,6 +989,9 @@ dojo.declare("classes.managers.ResourceManager", com.nuclearunicorn.core.TabMana
 	},
 
 	save: function(saveData){
+		saveData.resources = this.filterMetadata(
+			this.resources, ["name", "value", "unlocked", "isHidden", "isHiddenFromCrafting"]
+		);
 		saveData.res = {
 			isLocked: this.isLocked,
 			showHiddenResources: this.showHiddenResources || undefined

--- a/js/resources.js
+++ b/js/resources.js
@@ -815,6 +815,16 @@ dojo.declare("classes.managers.ResourceManager", com.nuclearunicorn.core.TabMana
 		this.updateMaxValue(this.get(resName));
 	},
 
+	/**
+	 * Updates the storage limits for ALL resources.
+	 */
+	updateMaxValueAll: function() {
+		for (var i in this.resources){
+			var res = this.resources[i];
+			this.updateMaxValue(res);
+		}
+	},
+
 	//All energy production amounts are multiplied by this number.
 	getEnergyProductionRatio: function() {
 		var game = this.game;

--- a/js/workshop.js
+++ b/js/workshop.js
@@ -359,6 +359,9 @@ dojo.declare("classes.managers.WorkshopManager", com.nuclearunicorn.core.TabMana
 		],
 		upgrades: {
 			buildings: ["accelerator"]
+		},
+		unlocks: {
+			upgrades: ["stasisChambers", "tachyonAccelerators"]
 		}
 	},{
 		name: "stasisChambers",
@@ -373,6 +376,9 @@ dojo.declare("classes.managers.WorkshopManager", com.nuclearunicorn.core.TabMana
 			{ name : "timeCrystal", val: 1 },
 			{ name : "alloy", val: 	 200 }
 		],
+		evaluateLocks: function(game){
+			return game.workshop.get("energyRifts").researched && game.science.get("chronophysics").researched;
+		},
 		upgrades: {
 			buildings: ["accelerator"]
 		},
@@ -452,6 +458,9 @@ dojo.declare("classes.managers.WorkshopManager", com.nuclearunicorn.core.TabMana
 			{ name : "timeCrystal", val: 10 },
 			{ name : "eludium",     val: 125 }
 		],
+		evaluateLocks: function(game){
+			return game.workshop.get("energyRifts").researched && game.science.get("tachyonTheory").researched;
+		},
 		upgrades: {
 			buildings: ["accelerator"]
 		}

--- a/res/i18n/en.json
+++ b/res/i18n/en.json
@@ -137,6 +137,7 @@
     "buildings.academy.flavor": "Curiosity is the basis of science. Our cats died nobly",
     "buildings.accelerator.label": "Accelerator",
     "buildings.accelerator.desc": "Converts titanium to the uranium (sic)",
+    "buildings.accelerator.desc2": "Storage bonuses remain effective even if powered off.",
     "buildings.accelerator.flavor": "Large Catron Collider",
     "buildings.aicore.label": "AI Core",
     "buildings.aicore.desc": "FelineOS, a state of the art artificial intelligence. Absolutely harmless. Every level of upgrade will increase Core energy consumption by 75%.",

--- a/res/i18n/en.json
+++ b/res/i18n/en.json
@@ -1872,6 +1872,7 @@
     "ui.filter.all": "All",
     "ui.filter.available": "Available",
     "ui.filter.enabled": "Enabled",
+    "ui.filter.ironWill": "IW",
     "ui.filter.togglable": "Togglable",
 
     "ui.kgnet.login": "Log in",


### PR DESCRIPTION
- Accelerators now show up as a “storage” building (in addition to being a “resources” building) on the Bonfire tab if & only if the Energy Rifts upgrade is researched.
- The description of Accelerators now explicitly specifies that you can turn off the building & still keep the storage effects.
- All Workshop upgrades that increase the storage capacity of Accelerators now have Energy Rifts somewhere in their prerequisites tree, as they are useless without it.
- Fix an obscure bug that happens if you load the game while pawsed, which you could exploit for all sorts of crazy things!