### PR TITLE
Save failure notifications

### DIFF
--- a/game.js
+++ b/game.js
@@ -306,13 +306,15 @@ dojo.declare("classes.game.Server", null, {
 
 	/**
 	 * Make an XHR request to KGNet server
-	 * 
+	 *
 	 * @param {string} url - relative endpoint URL
 	 * @param {*} method - "GET" or "POST"
 	 * @param {*} data - post data
 	 * @param {*} handler - onDone callback handler
+	 * @param {*} [errorHandler] - onFail callback handler, invoked with (jqXHR, textStatus)
 	 */
-	_xhr: function(url, method, data, handler){
+	_xhr: function(url, method, data, handler, errorHandler){
+		var self = this;
 		return $.ajax({
             cache: false,
             type: method || "GET",
@@ -324,7 +326,35 @@ dojo.declare("classes.game.Server", null, {
 			data: data
 		}).done(function(resp){
 			handler(resp);
+		}).fail(function(jqXHR, textStatus){
+			console.error("KGNet request failed:", method || "GET", url, "status:", jqXHR.status, textStatus);
+			if (jqXHR.status == 403){
+				//the HTTP session is gone (expired or revoked), the cached profile no longer reflects reality
+				self.setUserProfile(null);
+			}
+			if (errorHandler){
+				errorHandler(jqXHR, textStatus);
+			}
 		});
+	},
+
+	/**
+	 * Show a failed KGNet operation in the game log with a human-readable reason.
+	 * 403 means the session expired; status 0 means the server could not be reached at all.
+	 *
+	 * @param {string} i18nKey - operation message with a {0} placeholder for the reason
+	 * @param {*} jqXHR
+	 */
+	_notifyRequestError: function(i18nKey, jqXHR){
+		var reason;
+		if (jqXHR.status == 403){
+			reason = $I("ui.kgnet.error.auth");
+		} else if (jqXHR.status > 0){
+			reason = $I("ui.kgnet.error.status", [jqXHR.status]);
+		} else {
+			reason = $I("ui.kgnet.error.network");
+		}
+		this.game.msg($I(i18nKey, [reason]), "alert");
 	},
 
 	/**
@@ -353,10 +383,8 @@ dojo.declare("classes.game.Server", null, {
 		var self = this,
 			game = this.game;
 
-		game.lastBackup = new Date().getTime();
-
 		var saveData = this.game.save();
-		this._xhr("/kgnet/save/upload/", "POST", 
+		this._xhr("/kgnet/save/upload/", "POST",
 		{
 			//pre-parsing guid to avoid checking it on the backend side
 			guid: this.game.telemetry.guid,
@@ -367,11 +395,14 @@ dojo.declare("classes.game.Server", null, {
 					day: game.calendar.day
 				}
 			}
-		}, 
+		},
 		function(resp){
-			console.log("save successful?");
+			game.lastBackup = new Date().getTime();
 			self.saveData = resp;
 			self.game.msg($I("save.export.msg"));
+		},
+		function(jqXHR){
+			self._notifyRequestError("save.export.fail", jqXHR);
 		});
 	},
 
@@ -393,14 +424,19 @@ dojo.declare("classes.game.Server", null, {
 		},
 		function(resp){
 			self.saveData = resp;
+		},
+		function(jqXHR){
+			self._notifyRequestError("save.update.fail", jqXHR);
 		});
 	},
 
 	loadSave: function(guid){
 		var self = this;
 		this._xhr("/kgnet/save/" + guid + "/download/", "GET", {}, function(resp){
-			if (!resp.data){
+			if (!resp || !resp.data){
 				console.error("unable to load game data", resp);
+				self.game.msg($I("save.import.fail", [$I("ui.kgnet.error.nodata")]), "alert");
+				return;
 			}
 			var data = resp.data;
 			LCstorage["com.nuclearunicorn.kittengame.savedata"] = data;
@@ -410,6 +446,9 @@ dojo.declare("classes.game.Server", null, {
 			self.game.msg($I("save.import.msg"));
 
 			self.game.render();
+		},
+		function(jqXHR){
+			self._notifyRequestError("save.import.fail", jqXHR);
 		});
 	},
 
@@ -2610,8 +2649,14 @@ dojo.declare("com.nuclearunicorn.game.ui.GamePage", null, {
 
 		var preparedSaveData = this._prepareSaveData(saveData);
 		var saveDataString = this._saveDataToString(preparedSaveData);
-		LCstorage["com.nuclearunicorn.kittengame.savedata"] = saveDataString;
-		console.log("Game saved");
+		try {
+			LCstorage["com.nuclearunicorn.kittengame.savedata"] = saveDataString;
+			console.log("Game saved");
+		} catch (e) {
+			//most likely the localStorage quota is exceeded (or storage is blocked, e.g. private browsing)
+			console.error("Unable to save the game:", e);
+			this.msg($I("save.fail"), "alert");
+		}
 
 		this.ui.save();
 

--- a/res/i18n/en.json
+++ b/res/i18n/en.json
@@ -1390,8 +1390,12 @@
     "gift.metaphysics": "Got {0}!",
 
     "save.export.msg": "Save export successful!",
+    "save.export.fail": "Cloud save failed: {0}. Your progress was NOT uploaded!",
+    "save.fail": "Could not save the game — local storage is full or unavailable! Export your save manually to avoid losing progress.",
     "save.import.confirmation.msg": "Are your sure? This will overwrite your save!",
     "save.import.msg": "Save import successful!",
+    "save.import.fail": "Could not load the cloud save: {0}.",
+    "save.update.fail": "Could not update the cloud save: {0}.",
 
     "science.policyToggleBlocked.label": "Hide blocked policies",
     "science.policyToggleResearched.label": "Hide researched policies",
@@ -1881,6 +1885,10 @@
     "ui.kgnet.save.load": "↓ Load",
     "ui.kgnet.sync": "Sync cloud saves",
     "ui.kgnet.instructional": "<- Click this link to start. After data loads, click on the 'Create save'.",
+    "ui.kgnet.error.auth": "your session has expired, please log in again",
+    "ui.kgnet.error.status": "server error {0}",
+    "ui.kgnet.error.network": "could not reach the server",
+    "ui.kgnet.error.nodata": "the server returned no save data",
 
     "ui.toggle.researched": "Toggle Researched",
 

--- a/tools/mock-kgnet/README.md
+++ b/tools/mock-kgnet/README.md
@@ -32,6 +32,10 @@ server. `load` round-trips correctly as long as the server stays running.
 | POST   | `/kgnet/save/update/`              | Update label / archived flag         |
 | GET    | `/kgnet/save/:guid/download/`       | Fetch a save blob (`{ data }`)       |
 | POST   | `/kgnet/chiral/game/command/`       | Stubbed (returns `{}`)               |
+| POST   | `/user/login/`                      | Accepts any credentials              |
+| POST   | `/user/logout/`                     | No-op                                |
+| ANY    | `/mock/fail/:status`                | Force all game endpoints to return `:status` (e.g. `403` to simulate an expired session) |
+| ANY    | `/mock/ok`                          | Clear the forced status              |
 
 CORS is set to reflect the request origin with credentials allowed, since the
 client uses `xhrFields: { withCredentials: true }`.
@@ -43,3 +47,6 @@ client uses `xhrFields: { withCredentials: true }`.
   The server parses that back into nested objects.
 - There is no real auth — `/user/` always returns a session. To simulate a
   logged-out state, just don't run the server (the menu falls back to offline).
+- To exercise the client's error handling (e.g. the 403 expired-session path),
+  hit `POST /mock/fail/403`, do something in the online menu, then restore with
+  `POST /mock/ok`.

--- a/tools/mock-kgnet/server.js
+++ b/tools/mock-kgnet/server.js
@@ -21,6 +21,12 @@ const PORT = process.env.PORT || 7780;
 /** @type {Array<{guid:string,label:string,archived:boolean,index:object,timestamp:number,size:number,data:string}>} */
 const saves = [];
 
+// Failure injection: when non-zero, every /user/ and /kgnet/ endpoint returns
+// this HTTP status instead of its normal response. Toggle at runtime:
+//   curl -X POST localhost:7780/mock/fail/403   # simulate an expired session
+//   curl -X POST localhost:7780/mock/ok         # back to normal
+let forcedStatus = 0;
+
 // Saves are returned to the client without the (potentially huge) save blob.
 function snapshot() {
 	return saves.map(function (s) {
@@ -97,9 +103,36 @@ const server = http.createServer(async function (req, res) {
 		return send(req, res, 204);
 	}
 
+	// Failure-injection control endpoints (never affected by forcedStatus).
+	const fail = url.match(/^\/mock\/fail\/(\d{3})$/);
+	if (fail) {
+		forcedStatus = Number(fail[1]);
+		console.log("  -> forcing status", forcedStatus, "on all game endpoints");
+		return send(req, res, 200, { forcedStatus: forcedStatus });
+	}
+	if (url === "/mock/ok") {
+		forcedStatus = 0;
+		console.log("  -> back to normal responses");
+		return send(req, res, 200, { forcedStatus: forcedStatus });
+	}
+
+	if (forcedStatus) {
+		return send(req, res, forcedStatus, { error: "forced by /mock/fail/" + forcedStatus });
+	}
+
 	// Active session — any truthy id makes the client treat the user as logged in.
 	if (url === "/user/" && method === "GET") {
 		return send(req, res, 200, { id: 1, username: "mockkitten" });
+	}
+
+	// Login/logout — accepts any credentials.
+	if (url === "/user/login/" && method === "POST") {
+		await readBody(req);
+		return send(req, res, 200, { id: 1, username: "mockkitten" });
+	}
+	if (url === "/user/logout/" && method === "POST") {
+		await readBody(req);
+		return send(req, res, 200, {});
 	}
 
 	// List cloud saves.


### PR DESCRIPTION
Currently the game silently fails if KGnet returns a 403 on a save...

We now report this to the user and show the logged out state when we encounter a 403...


<img width="1032" height="451" alt="image" src="https://github.com/user-attachments/assets/1716c1d1-4cca-46e3-bf58-da47be5dfff2" />

Here's Claude's write-up...

## Notify the player when saving fails instead of failing silently

### Problem

KGNet requests in `classes.game.Server` only registered a `.done()` handler — there was no `.fail()` anywhere. When a cloud save upload failed (most commonly a **403 from an expired session**), nothing happened: no game-log message, no console output, and `pushSave` had already stamped `lastBackup` *before* the request fired, so the game recorded a successful backup that never took place. The toolbar kept showing "Online" indefinitely.

### Changes

**Cloud saves (`game.js`)**
- `_xhr` now takes an optional error handler and always attaches `.fail()`: every failed request is logged to the console, and a 403 clears the cached `userProfile` so the toolbar indicator flips to offline instead of lying.
- `pushSave`, `loadSave`, and `pushSaveMetadata` report failures in the game log (red `alert` style) with a specific reason via the new `_notifyRequestError` helper:
  - 403 → *"…your session has expired, please log in again"*
  - other HTTP errors → *"…server error {status}"*
  - status 0 → *"…could not reach the server"*
- `lastBackup` now only updates when the upload actually succeeds.
- Fixed a destructive edge case in `loadSave`: a 200 response with no `data` used to fall through and overwrite the local save with `undefined`. It now notifies and bails out.

**Local saves**
- The `LCstorage` write in `save()` is wrapped in try/catch, so a full or blocked localStorage (5MB quota, private browsing) shows *"Could not save the game — export your save manually…"* instead of throwing past the player. Note this fires on every autosave while storage stays full — intentionally loud, since progress genuinely isn't persisting.

**Dev tooling (`tools/mock-kgnet`)**
- The mock KGNet backend gained failure injection so this is testable locally: `POST /mock/fail/403` forces every game endpoint to return that status (any code works), `POST /mock/ok` restores normal behavior. Also added `/user/login/` and `/user/logout/` so the toolbar login form round-trips.

**i18n** — new strings in `en.json` (`save.export.fail`, `save.fail`, `save.import.fail`, `save.update.fail`, `ui.kgnet.error.*`); other locales fall back to English until translated.

### Testing

- `yarn test` (56 passing), `yarn eslint`, `yarn typecheck` all clean.
- Verified end-to-end in a browser against the mock: save succeeds → force 403 → save shows the red failure message and the toolbar flips to "Log in" → restore, re-login, save succeeds again. No page errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
