### PR TITLE
feat: indicators for capped resources in trading panels

### DIFF
--- a/js/diplomacy.js
+++ b/js/diplomacy.js
@@ -1909,11 +1909,19 @@ dojo.declare("com.nuclearunicorn.game.ui.tab.Diplomacy", com.nuclearunicorn.game
 				var res = this.game.resPool.get(s.name);
 				var average = s.value * tradeRatio * tradeVolume * (1 + race.energy * 0.02) * (1 + (s.seasons ? s.seasons[currentSeason] : 0));
 
+				var capPercentageMarkUp = "";
+				//Only capped resources gets percentage indicator eg wood, oil, coal
+				if (res.maxValue > 0){
+					var capPercentage = Math.round(res.value / res.maxValue * 100);
+					var capColor = capPercentage > 90 ? "coral" : "";
+					capPercentageMarkUp = "<span style='color: " + capColor + ";'> " + capPercentage + "%</span>";
+				}
+
 				var prefix = j == 0 ? "<span class='sells'>" + $I("trade.sells") + ": </span>" : "<span class='sells'></span>";
 				dojo.create("div", {
 						innerHTML: prefix + (res.title || res.name) + " <span class='tradeAmount'>"
 							+ this.game.getDisplayValueExt(average * (1 - s.width / 2), false, false, 0) + " - "
-							+ this.game.getDisplayValueExt(average * (1 + s.width / 2), false, false, 0) + "</span>"
+							+ this.game.getDisplayValueExt(average * (1 + s.width / 2), false, false, 0) + "</span>" + capPercentageMarkUp
 					}, leftColumn);
 			}
 			if (race.name == "zebras") {


### PR DESCRIPTION
In mobile when scrolled down to the crafting section of the left sidebar it's hard to see what resources are hitting their limits when in the trade tab. So I have added a percentage indicator next to the resources that a race sells to show whether the resource is hitting capacity, with the indicator text being red (coral) if above 90%