### PR TITLE
Retain resource visibility after reset

### DIFF
--- a/game.js
+++ b/game.js
@@ -5483,6 +5483,8 @@ dojo.declare("com.nuclearunicorn.game.ui.GamePage", null, {
 			saveData.science.techs.push(this.science.get("chronophysics"));
 		}
 
+		this.resPool.save(saveData);
+
 		var preparedSaveData = this._prepareSaveData(saveData);
 		var saveDataString = this._saveDataToString(preparedSaveData);
 		LCstorage["com.nuclearunicorn.kittengame.savedata"] = saveDataString;


### PR DESCRIPTION
I want to always see the hidden resources, which is why I looked into this. It seems like this change would also ensure other resource visibility configurations are retained, which seems like it would benefit users.