### PR TITLE
 Fix few bugs related to biomes

### DIFF
--- a/game.js
+++ b/game.js
@@ -4257,7 +4257,7 @@ var GamePage = dojo.declare("com.nuclearunicorn.game.ui.GamePage", null, {
 		});
 
 		// BIOME EXPLORATION
-		if (res.name == "manpower"){
+		if (res.name == "manpower" && this.village.map.currentBiome){
 			var biome = this.village.getBiome(this.village.map.currentBiome);
 			if (biome){
 				var exploreCost = this.village.map.getExplorationCost();

--- a/game.js
+++ b/game.js
@@ -3829,6 +3829,10 @@ var GamePage = dojo.declare("com.nuclearunicorn.game.ui.GamePage", null, {
 		perTick *= (1 + this.getEffect(res.name + "PolicyRatio"));
 
 		perTick += resConsumption;
+		if (res.name == "manpower" && this.village.map.currentBiome){
+			var exploreCost = this.village.map.getExplorationCost();
+			perTick -= exploreCost;
+		}
 		if (isNaN(perTick)){
 			return 0;
 		}

--- a/game.js
+++ b/game.js
@@ -3829,10 +3829,6 @@ var GamePage = dojo.declare("com.nuclearunicorn.game.ui.GamePage", null, {
 		perTick *= (1 + this.getEffect(res.name + "PolicyRatio"));
 
 		perTick += resConsumption;
-		if (res.name == "manpower" && this.village.map.currentBiome){
-			var exploreCost = this.village.map.getExplorationCost();
-			perTick -= exploreCost;
-		}
 		if (isNaN(perTick)){
 			return 0;
 		}
@@ -4623,7 +4619,8 @@ var GamePage = dojo.declare("com.nuclearunicorn.game.ui.GamePage", null, {
 	getResourcePerTickConvertion: function(resName) {
 		return this.fixFloatPointNumber(this.getEffect(resName + "PerTickCon") -
 			/*use subtraction because getAmbassadorEffect returns positive value*/
-			this.diplomacy.getAmbassadorEffect(resName + "ConsumptionAmbassadors"));
+			this.diplomacy.getAmbassadorEffect(resName + "ConsumptionAmbassadors"))
+			- (resName == "manpower" && this.village.map.currentBiome) ? this.village.map.getExplorationCost() : 0;
 	},
 
 	/**

--- a/res/i18n/en.json
+++ b/res/i18n/en.json
@@ -1275,6 +1275,7 @@
     "res.stack.engineer": "(:3) Engineer",
     "res.stack.environmentPolicy": "Environmental policy",
     "res.stack.expansionism" : "Cosmoliberalism bonus",
+    "res.stack.exploration": "Exploration",
     "res.stack.extermination" : "Pacts",
     "res.stack.faith": "Faith",
     "res.stack.holyGenocide": "Holy Genocide",


### PR DESCRIPTION
1. No longer throw errors when hovering over manpower when no biome is selected.
2. Added ` "res.stack.exploration": "Exploration",` to make the game actually display the spent catpower on exploring biomes.